### PR TITLE
Change withDraft() to return BouncerRecord entity instead of bool

### DIFF
--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -6,6 +6,9 @@ namespace Bouncer\Controller\Admin;
 
 use App\Controller\AppController;
 use Cake\Event\EventInterface;
+use DateTime;
+use Exception;
+use RuntimeException;
 
 /**
  * Bouncer Controller
@@ -93,7 +96,7 @@ class BouncerController extends AppController
             try {
                 $sourceTable = $this->fetchTable($bouncerRecord->source);
                 $currentRecord = $sourceTable->get($bouncerRecord->primary_key);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $this->Flash->warning('The original record no longer exists.');
             }
         }
@@ -140,7 +143,7 @@ class BouncerController extends AppController
                 $entity = $behavior->applyApprovedChanges($bouncerRecord);
 
                 if (!$entity) {
-                    throw new \RuntimeException('Failed to apply changes to ' . $bouncerRecord->source);
+                    throw new RuntimeException('Failed to apply changes to ' . $bouncerRecord->source);
                 }
 
                 $primaryKeyField = $sourceTable->getPrimaryKey();
@@ -150,18 +153,18 @@ class BouncerController extends AppController
                 $this->BouncerRecords->patchEntity($bouncerRecord, [
                     'status' => 'approved',
                     'reviewer_id' => $this->request->getAttribute('identity')?->getIdentifier(),
-                    'reviewed' => new \DateTime(),
+                    'reviewed' => new DateTime(),
                     'reason' => $this->request->getData('reason'),
                     'primary_key' => $primaryKeyValue, // Set for new records
                 ]);
 
                 if (!$this->BouncerRecords->save($bouncerRecord)) {
-                    throw new \RuntimeException('Failed to update bouncer record.');
+                    throw new RuntimeException('Failed to update bouncer record.');
                 }
             });
 
             $this->Flash->success('Changes have been approved and published.');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->Flash->error('Failed to approve changes: ' . $e->getMessage());
 
             return $this->redirect(['action' => 'view', $id]);
@@ -192,7 +195,7 @@ class BouncerController extends AppController
         $this->BouncerRecords->patchEntity($bouncerRecord, [
             'status' => 'rejected',
             'reviewer_id' => $this->request->getAttribute('identity')?->getIdentifier(),
-            'reviewed' => new \DateTime(),
+            'reviewed' => new DateTime(),
             'reason' => $this->request->getData('reason'),
         ]);
 

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Bouncer\Model\Behavior;
 
 use ArrayObject;
+use Bouncer\Model\Entity\BouncerRecord;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use RuntimeException;
 
 /**
  * Bouncer Behavior
@@ -459,7 +461,7 @@ class BouncerBehavior extends Behavior
 
         $encoded = json_encode($data);
         if ($encoded === false) {
-            throw new \RuntimeException('Failed to encode entity data');
+            throw new RuntimeException('Failed to encode entity data');
         }
 
         return $encoded;
@@ -621,24 +623,27 @@ class BouncerBehavior extends Behavior
      * Convenience method that loads a pending draft for the given user
      * and overlays the draft data onto the entity for display/editing.
      *
+     * Returns the draft entity if found and applied, allowing access to
+     * original data via `$draft->getOriginalData()` for comparison/diff views.
+     *
      * @param \Cake\Datasource\EntityInterface $entity Entity to overlay draft on
      * @param int $userId User ID
      *
-     * @return bool True if draft was found and applied, false otherwise
+     * @return \Bouncer\Model\Entity\BouncerRecord|null The draft entity if found and applied, null otherwise
      */
-    public function withDraft(EntityInterface $entity, int $userId): bool
+    public function withDraft(EntityInterface $entity, int $userId): ?BouncerRecord
     {
         $primaryKeyField = $this->_table->getPrimaryKey();
         $primaryKey = $entity->get(is_array($primaryKeyField) ? $primaryKeyField[0] : $primaryKeyField);
 
         if (!$primaryKey) {
-            return false;
+            return null;
         }
 
         $draft = $this->loadDraft((int)$primaryKey, $userId);
 
         if (!$draft) {
-            return false;
+            return null;
         }
 
         // Overlay draft data onto the entity
@@ -646,12 +651,12 @@ class BouncerBehavior extends Behavior
 
         // Don't overlay delete drafts - they only contain {_delete: true}
         if (isset($draftData['_delete']) && $draftData['_delete'] === true) {
-            return false;
+            return null;
         }
 
         $this->_table->patchEntity($entity, $draftData);
 
-        return true;
+        return $draft;
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bouncer\Test\TestCase\Model\Behavior;
 
+use Bouncer\Model\Entity\BouncerRecord;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\TestSuite\TestCase;
 
@@ -689,16 +690,22 @@ class BouncerBehaviorTest extends TestCase
         $this->assertEquals('Original Title', $article->title);
         $this->assertEquals('Original Body', $article->body);
 
-        // Apply draft
-        $hasDraft = $this->Articles->getBehavior('Bouncer')->withDraft($article, 1);
+        // Apply draft - now returns the draft entity instead of bool
+        $draft = $this->Articles->getBehavior('Bouncer')->withDraft($article, 1);
 
-        $this->assertTrue($hasDraft);
+        $this->assertNotNull($draft);
+        $this->assertInstanceOf(BouncerRecord::class, $draft);
         $this->assertEquals('Draft Title', $article->title);
         $this->assertEquals('Draft Body', $article->body);
+
+        // Verify we can access original data from the draft
+        $originalData = $draft->getOriginalData();
+        $this->assertEquals('Original Title', $originalData['title']);
+        $this->assertEquals('Original Body', $originalData['body']);
     }
 
     /**
-     * Test withDraft() returns false when no draft exists
+     * Test withDraft() returns null when no draft exists
      *
      * @return void
      */
@@ -719,9 +726,9 @@ class BouncerBehaviorTest extends TestCase
 
         // Try to apply draft when none exists
         $article = $this->Articles->get($article->id);
-        $hasDraft = $this->Articles->getBehavior('Bouncer')->withDraft($article, 1);
+        $draft = $this->Articles->getBehavior('Bouncer')->withDraft($article, 1);
 
-        $this->assertFalse($hasDraft);
+        $this->assertNull($draft);
         $this->assertEquals('Test Title', $article->title);
         $this->assertEquals('Test Body', $article->body);
     }


### PR DESCRIPTION
## Summary
- Modified `withDraft()` to return `BouncerRecord|null` instead of `bool`
- This allows callers to access the original data from the draft record without making a second database query

## Use Case
Previously, if you wanted to show a diff or access the original values after applying a draft, you had to:
1. Call `hasPendingDraft()` to check if a draft exists
2. Call `withDraft()` to apply it (which loads the draft again)
3. Make another query to get the original data

Now you can do:
```php
$draft = $bouncer->withDraft($entity, $userId);
if ($draft) {
    $original = $draft->getOriginalData();
    // Show diff between $entity (modified) and $original
}
```
