### PR TITLE
Fix: Block save when bouncer record creation fails

### DIFF
--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -54,6 +54,13 @@ class BouncerBehavior extends Behavior
     protected $lastBouncerRecord;
 
     /**
+     * Tracks if last bouncer operation failed (vs. intentionally skipped).
+     *
+     * @var bool
+     */
+    protected bool $bouncerFailed = false;
+
+    /**
      * Initialize hook.
      *
      * @param array<string, mixed> $config Configuration
@@ -80,6 +87,7 @@ class BouncerBehavior extends Behavior
     {
         $this->wasBounced = false;
         $this->lastBouncerRecord = null;
+        $this->bouncerFailed = false;
 
         // Check if we should bypass bouncer
         if ($this->shouldBypass($entity, $options)) {
@@ -121,10 +129,17 @@ class BouncerBehavior extends Behavior
         $bouncerRecord = $this->createBouncerRecord($entity, $options);
 
         if (!$bouncerRecord) {
-            // No bouncer record created - this could mean:
-            // 1. Draft was removed because changes were reverted to original
-            // 2. No actual changes to approve
-            // In either case, allow the save to proceed normally
+            // @phpstan-ignore if.alwaysFalse (createBouncerRecord sets this property)
+            if ($this->bouncerFailed) {
+                // Bouncer record creation failed - block the save to prevent bypass
+                $event->stopPropagation();
+                $event->setResult(false);
+
+                return;
+            }
+
+            // No bouncer record created intentionally (reverted to original, no changes)
+            // Allow the save to proceed normally
             return;
         }
 
@@ -151,6 +166,7 @@ class BouncerBehavior extends Behavior
     {
         $this->wasBounced = false;
         $this->lastBouncerRecord = null;
+        $this->bouncerFailed = false;
 
         // Check if we should bypass bouncer
         if ($this->shouldBypass($entity, $options)) {
@@ -195,6 +211,8 @@ class BouncerBehavior extends Behavior
 
         $userId = $this->getUserId($entity, $options);
         if (!$userId) {
+            $this->bouncerFailed = true;
+
             return null;
         }
 
@@ -312,6 +330,8 @@ class BouncerBehavior extends Behavior
         }
 
         if (!$bouncerRecord) {
+            $this->bouncerFailed = true;
+
             return null;
         }
 
@@ -353,6 +373,8 @@ class BouncerBehavior extends Behavior
 
         $userId = $this->getUserId($entity, $options);
         if (!$userId) {
+            $this->bouncerFailed = true;
+
             return null;
         }
 
@@ -409,6 +431,8 @@ class BouncerBehavior extends Behavior
         }
 
         if (!$bouncerRecord) {
+            $this->bouncerFailed = true;
+
             return null;
         }
 

--- a/tests/Fixture/UuidArticlesFixture.php
+++ b/tests/Fixture/UuidArticlesFixture.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * UuidArticlesFixture - Articles with UUID primary key and user_id
+ */
+class UuidArticlesFixture extends TestFixture
+{
+    /**
+     * Table name
+     *
+     * @var string
+     */
+    public string $table = 'uuid_articles';
+
+    /**
+     * Fields
+     *
+     * @var array<string, mixed>
+     */
+    public array $fields = [
+        'id' => ['type' => 'uuid', 'null' => false, 'default' => null],
+        'title' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null],
+        'body' => ['type' => 'text', 'null' => true, 'default' => null],
+        'user_id' => ['type' => 'uuid', 'null' => false, 'default' => null],
+        'created' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null],
+        'modified' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ];
+
+    /**
+     * Records
+     *
+     * @var list<array>
+     */
+    public array $records = [];
+
+    /**
+     * Init method
+     *
+     * @return void
+     */
+    public function init(): void
+    {
+        $this->records = [];
+        parent::init();
+    }
+}

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorUuidTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorUuidTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Test\TestCase\Model\Behavior;
+
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Text;
+use InvalidArgumentException;
+
+/**
+ * Tests for UUID type mismatch scenarios
+ *
+ * This tests the scenario where the source table uses UUID for primary_key
+ * and user_id, but the bouncer_records table uses integer fields.
+ *
+ * When there's a type mismatch, CakePHP throws an InvalidArgumentException
+ * which is the expected behavior - it clearly indicates a configuration problem.
+ *
+ * To fix this, users must copy and adjust the migration to use UUID types
+ * for the bouncer_records table fields (primary_key, user_id, reviewer_id).
+ */
+class BouncerBehaviorUuidTest extends TestCase
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var list<string>
+     */
+    protected array $fixtures = [
+        'plugin.Bouncer.BouncerRecords',
+        'plugin.Bouncer.UuidArticles',
+    ];
+
+    /**
+     * @var \TestApp\Model\Table\UuidArticlesTable
+     */
+    protected $UuidArticles;
+
+    /**
+     * @var \Bouncer\Model\Table\BouncerRecordsTable
+     */
+    protected $BouncerRecords;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->UuidArticles = $this->fetchTable('TestApp.UuidArticles');
+        $this->BouncerRecords = $this->fetchTable('Bouncer.BouncerRecords');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        unset($this->UuidArticles, $this->BouncerRecords);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that UUID user_id with integer bouncer_records.user_id throws exception
+     *
+     * When the bouncer_records table has integer fields but UUIDs are passed,
+     * CakePHP will throw an InvalidArgumentException. This is the expected
+     * behavior - it clearly indicates a configuration problem.
+     *
+     * Solution: Copy the migration to app and change field types to UUID.
+     */
+    public function testUuidUserIdWithIntegerBouncerFieldThrowsException(): void
+    {
+        $this->UuidArticles->addBehavior('Bouncer.Bouncer', [
+            'userField' => 'user_id',
+        ]);
+
+        $uuid = Text::uuid();
+        $userUuid = Text::uuid();
+
+        $article = $this->UuidArticles->newEntity([
+            'id' => $uuid,
+            'title' => 'Test Article',
+            'body' => 'Test body',
+            'user_id' => $userUuid,
+        ]);
+
+        // CakePHP throws InvalidArgumentException when trying to convert UUID to int
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot convert value');
+
+        $this->UuidArticles->save($article, ['bouncerUserId' => $userUuid]);
+    }
+
+    /**
+     * Test that edit with UUID primary key and integer bouncer_records.primary_key throws exception
+     */
+    public function testUuidPrimaryKeyWithIntegerBouncerFieldThrowsException(): void
+    {
+        // First create an article bypassing bouncer
+        $uuid = Text::uuid();
+        $userUuid = Text::uuid();
+
+        $article = $this->UuidArticles->newEntity([
+            'id' => $uuid,
+            'title' => 'Original Title',
+            'body' => 'Original body',
+            'user_id' => $userUuid,
+        ]);
+        $this->UuidArticles->save($article, ['bypassBouncer' => true]);
+
+        // Now add bouncer behavior and try to edit
+        $this->UuidArticles->addBehavior('Bouncer.Bouncer', [
+            'userField' => 'user_id',
+        ]);
+
+        $article = $this->UuidArticles->get($uuid);
+        $article->title = 'Updated Title';
+
+        // CakePHP throws InvalidArgumentException when trying to convert UUID to int
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot convert value');
+
+        $this->UuidArticles->save($article, ['bouncerUserId' => $userUuid]);
+    }
+}

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorValidationTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorValidationTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Test\TestCase\Model\Behavior;
+
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests for bouncer record validation failure scenarios
+ *
+ * This tests the scenario where the bouncer record fails validation,
+ * ensuring the original save does NOT proceed.
+ */
+class BouncerBehaviorValidationTest extends TestCase
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var list<string>
+     */
+    protected array $fixtures = [
+        'plugin.Bouncer.BouncerRecords',
+        'plugin.Bouncer.Articles',
+    ];
+
+    /**
+     * @var \TestApp\Model\Table\ArticlesTable
+     */
+    protected $Articles;
+
+    /**
+     * @var \Bouncer\Model\Table\BouncerRecordsTable
+     */
+    protected $BouncerRecords;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->Articles = $this->fetchTable('TestApp.Articles');
+        $this->BouncerRecords = $this->fetchTable('Bouncer.BouncerRecords');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        unset($this->Articles, $this->BouncerRecords);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that when bouncer record validation fails, the original save does NOT proceed
+     *
+     * This test adds an artificial validation rule to BouncerRecords that will always fail,
+     * simulating a scenario like UUID/integer type mismatch at validation level.
+     *
+     * BUG: Currently when bouncer record save fails, the original save proceeds!
+     */
+    public function testBouncerValidationFailureAllowsOriginalSaveThrough(): void
+    {
+        // Add artificial validation rule that always fails
+        $validator = $this->BouncerRecords->getValidator('default');
+        $validator->add('user_id', 'alwaysFail', [
+            'rule' => function ($value) {
+                // Simulate validation failure (e.g., UUID passed to integer field)
+                return false;
+            },
+            'message' => 'Simulated validation failure',
+        ]);
+
+        $this->Articles->addBehavior('Bouncer.Bouncer', [
+            'userField' => 'user_id',
+        ]);
+
+        $article = $this->Articles->newEntity([
+            'title' => 'Test Article',
+            'body' => 'Test body',
+            'user_id' => 1,
+        ]);
+
+        // Try to save - bouncer record validation will fail
+        $result = $this->Articles->save($article, ['bouncerUserId' => 1]);
+
+        // BUG: The save should be blocked (return false) because bouncer couldn't create record
+        // But currently it proceeds and saves the article directly!
+        $this->assertFalse($result, 'Save should fail when bouncer record validation fails');
+
+        // Verify no bouncer record was created
+        $bouncerCount = $this->BouncerRecords->find()->count();
+        $this->assertEquals(0, $bouncerCount, 'No bouncer record should exist');
+
+        // BUG: Article should NOT exist because save should have been blocked
+        $articleCount = $this->Articles->find()->count();
+        $this->assertEquals(0, $articleCount, 'Article should not be saved when bouncer validation fails');
+    }
+
+    /**
+     * Test edit scenario: bouncer validation failure should not update original record
+     */
+    public function testBouncerValidationFailureOnEditDoesNotUpdateOriginal(): void
+    {
+        // First create an article bypassing bouncer
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article, ['bypassBouncer' => true]);
+        $articleId = $article->id;
+
+        // Now add artificial validation rule that always fails
+        $validator = $this->BouncerRecords->getValidator('default');
+        $validator->add('user_id', 'alwaysFail', [
+            'rule' => function ($value) {
+                return false;
+            },
+            'message' => 'Simulated validation failure',
+        ]);
+
+        $this->Articles->addBehavior('Bouncer.Bouncer', [
+            'userField' => 'user_id',
+        ]);
+
+        // Try to edit
+        $article = $this->Articles->get($articleId);
+        $article->title = 'Updated Title';
+
+        $result = $this->Articles->save($article, ['bouncerUserId' => 1]);
+
+        // BUG: The save should fail because bouncer couldn't create record
+        $this->assertFalse($result, 'Edit should fail when bouncer record validation fails');
+
+        // BUG: Article should still have original title
+        $article = $this->Articles->get($articleId);
+        $this->assertEquals('Original Title', $article->title, 'Article should not be updated when bouncer validation fails');
+    }
+}

--- a/tests/test_app/src/Model/Table/UuidArticlesTable.php
+++ b/tests/test_app/src/Model/Table/UuidArticlesTable.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+
+/**
+ * UuidArticles Table - uses UUID for primary key and user_id
+ */
+class UuidArticlesTable extends Table
+{
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('uuid_articles');
+        $this->setDisplayField('title');
+        $this->setPrimaryKey('id');
+
+        $this->addBehavior('Timestamp');
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes security issue where changes could bypass approval workflow when bouncer record creation failed
- Introduces `bouncerFailed` flag to distinguish between "not needed" and "failed" scenarios
- Adds comprehensive test coverage for UUID type mismatch and validation failure scenarios

## Problem

When the bouncer record creation fails (due to validation errors, type mismatches, etc.), the code previously allowed the original save to proceed. This means changes that should require approval could bypass the entire workflow if there was any issue with creating the bouncer record.

For example, if someone uses UUIDs for user IDs but the `bouncer_records` table has integer fields (and the validation fails), the original entity would be saved directly without approval.

## Solution

Added a `bouncerFailed` property that tracks whether bouncer record creation genuinely failed vs. was intentionally skipped. When a failure occurs, the save is now blocked to prevent bypass.

## Test plan

- [x] Added `BouncerBehaviorValidationTest` with artificial validation failure
- [x] Added `BouncerBehaviorUuidTest` for UUID type mismatch scenarios
- [x] All existing tests pass (39 tests, 159 assertions)
- [x] PHPStan passes
- [x] Code style checks pass