### PR TITLE
Add conflict resolution for concurrent edits

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 end_of_line = lf
 insert_final_newline = true
@@ -13,8 +13,7 @@ trim_trailing_whitespace = true
 end_of_line = crlf
 
 [*.yml]
-indent_style = space
 indent_size = 2
 
-[*.md]
-indent_style = space
+[*.neon]
+indent_style = tab

--- a/config/Migrations/20251203000000_AddOriginalModified.php
+++ b/config/Migrations/20251203000000_AddOriginalModified.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class AddOriginalModified extends BaseMigration
+{
+    /**
+     * Up
+     */
+    public function up(): void
+    {
+        $this->table('bouncer_records')
+            ->addColumn('original_modified', 'datetime', [
+                'default' => null,
+                'null' => true,
+                'after' => 'original_data',
+                'comment' => 'Timestamp of source record when draft was created',
+            ])
+            ->update();
+    }
+
+    /**
+     * Down
+     */
+    public function down(): void
+    {
+        $this->table('bouncer_records')
+            ->removeColumn('original_modified')
+            ->update();
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -343,9 +343,31 @@ $bouncerRecord->setMergedData($mergedData);
 $bouncer->applyApprovedChanges($bouncerRecord);
 ```
 
+### Using BouncerRecord Helper Methods
+
+The `BouncerRecord` entity provides convenient methods for staleness detection and merging:
+
+```php
+// Check if a draft is stale (source record was modified after draft creation)
+if ($bouncerRecord->isStale($currentEntity)) {
+    // Handle stale draft
+}
+
+// Build merge result (returns null if not stale)
+$mergeResult = $bouncerRecord->buildMergeResult($currentEntity);
+if ($mergeResult) {
+    // $mergeResult contains: merged, conflicts, autoMerged, hasConflicts
+    if ($mergeResult['hasConflicts']) {
+        // Handle conflicts
+    } else {
+        // Use $mergeResult['merged'] for the auto-merged data
+    }
+}
+```
+
 ### Using ThreeWayMerge Directly
 
-For display purposes or custom merge logic:
+For advanced use cases or custom merge logic:
 
 ```php
 use Bouncer\Lib\ThreeWayMerge;

--- a/docs/README.md
+++ b/docs/README.md
@@ -289,3 +289,78 @@ If your application uses UUIDs for primary keys or user IDs, you need to copy an
 3. Run the migration from your app: `bin/cake migrations migrate`
 
 **Note:** Do not run the plugin migration directly if you need UUID support - use your adjusted app migration instead.
+
+## 3-Way Merge for Stale Proposals
+
+When a proposal becomes "stale" (the source record has been modified since the proposal was created), Bouncer automatically performs a 3-way merge to preserve both sets of changes when possible.
+
+### How It Works
+
+1. **Staleness Detection**: Proposals store the original `modified` timestamp (`original_modified`). When approving, Bouncer compares this with the current record's `modified` timestamp.
+
+2. **Automatic Merge**: If the source record has been modified, `applyApprovedChanges()` automatically:
+   - Loads the current record state
+   - Performs a 3-way merge between original, current, and proposed data
+   - Applies the merged result
+
+3. **Conflict Resolution**:
+   - **Non-overlapping changes**: Both sets of changes are preserved (e.g., owner removes typo, contributor fixes spelling elsewhere)
+   - **Overlapping changes**: Proposed value takes precedence (can be customized)
+
+### Example Scenario
+
+```
+Original:  "Hello!!!! World"
+Current:   "Hello World"      (owner removed "!!!!")
+Proposed:  "Hello!!!! Universe" (contributor changed "World" to "Universe")
+Merged:    "Hello Universe"   (both changes preserved!)
+```
+
+### Options for `applyApprovedChanges()`
+
+```php
+$bouncer->applyApprovedChanges($bouncerRecord, [
+    // Disable auto-merge to use proposed data as-is (default: true)
+    'autoMerge' => false,
+
+    // Custom fields to skip during merge
+    'skipFields' => ['id', 'created', 'modified', 'internal_field'],
+]);
+```
+
+### Pre-Merging Data
+
+For custom merge logic or UI-driven conflict resolution, you can pre-merge data:
+
+```php
+// Build your own merged data
+$mergedData = ['title' => 'Custom merged title', ...];
+
+// Set it on the bouncer record
+$bouncerRecord->setMergedData($mergedData);
+
+// Apply - will use your merged data instead of auto-merging
+$bouncer->applyApprovedChanges($bouncerRecord);
+```
+
+### Using ThreeWayMerge Directly
+
+For display purposes or custom merge logic:
+
+```php
+use Bouncer\Lib\ThreeWayMerge;
+
+$merger = new ThreeWayMerge();
+
+// Merge string values
+$result = $merger->mergeStrings($original, $current, $proposed);
+if ($result['status'] === ThreeWayMerge::MERGED) {
+    echo $result['result']; // Successfully merged
+} else {
+    // ThreeWayMerge::CONFLICT - manual resolution needed
+}
+
+// Merge arrays of entity data
+$result = $merger->mergeArrays($originalData, $currentData, $proposedData);
+// Returns: merged, conflicts, autoMerged, hasConflicts
+```

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -240,6 +240,9 @@ class BouncerController extends AppController
             $currValue = $current[$field] ?? null;
             $propValue = $proposed[$field] ?? null;
 
+            // Skip fields not in the original proposal - we only care about proposed changes
+            $inProposed = array_key_exists($field, $proposed);
+
             // Skip if no changes
             $currentChanged = $origValue !== $currValue;
             $proposedChanged = $origValue !== $propValue;
@@ -250,13 +253,20 @@ class BouncerController extends AppController
 
             // If only one side changed, use that change
             if (!$currentChanged) {
-                $merged[$field] = $propValue;
-
+                // Only proposed changed - keep proposed value (already in $merged)
                 continue;
             }
             if (!$proposedChanged) {
-                $merged[$field] = $currValue;
+                // Only current changed - update merged only if field was in proposed
+                if ($inProposed) {
+                    $merged[$field] = $currValue;
+                }
 
+                continue;
+            }
+
+            // Both changed - only process if field was in proposed
+            if (!$inProposed) {
                 continue;
             }
 

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -154,15 +154,15 @@ class BouncerController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
-        // Check if there's actually a conflict
-        $hasConflict = false;
+        // Check if record is stale (modified after draft was created)
+        $isStale = false;
         if ($bouncerRecord->canDetectStaleness()) {
             $currentModified = $currentRecord->get('modified') ?? $currentRecord->get('created');
-            $hasConflict = $currentModified && $currentModified > $bouncerRecord->original_modified;
+            $isStale = $currentModified && $currentModified > $bouncerRecord->original_modified;
         }
 
-        if (!$hasConflict) {
-            $this->Flash->info('No conflict detected. You can proceed with normal approval.');
+        if (!$isStale) {
+            $this->Flash->info('No changes detected since draft creation. You can proceed with normal approval.');
 
             return $this->redirect(['action' => 'view', $id]);
         }

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -356,8 +356,8 @@ class BouncerController extends AppController
                         return $this->redirect(['action' => 'resolve', $id]);
                     }
 
-                    // Update bouncer record with merged data
-                    $bouncerRecord->data = json_encode($conflict['merged'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+                    // Set merged data - this prevents the behavior from auto-merging again
+                    $bouncerRecord->setMergedData($conflict['merged']);
                 }
             } catch (Exception $e) {
                 // Source record no longer exists - continue with approval (will fail gracefully)

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bouncer\Controller\Admin;
 
 use App\Controller\AppController;
+use Bouncer\Lib\ThreeWayMerge;
 use Cake\Event\EventInterface;
 use DateTime;
 use Exception;
@@ -201,15 +202,20 @@ class BouncerController extends AppController
     /**
      * Build a 3-way diff for conflict resolution.
      *
+     * Attempts to auto-merge non-overlapping changes and identifies true conflicts.
+     *
      * @param array<string, mixed> $original Original data when draft was created
      * @param array<string, mixed> $current Current live data
      * @param array<string, mixed> $proposed Proposed changes in draft
      *
-     * @return array{original: array, current: array, proposed: array, conflicts: array<string, array>, hasConflicts: bool}
+     * @return array{original: array, current: array, proposed: array, merged: array, conflicts: array<string, array>, autoMerged: array<string, array>, hasConflicts: bool}
      */
     protected function buildThreeWayDiff(array $original, array $current, array $proposed): array
     {
         $conflicts = [];
+        $autoMerged = [];
+        $merged = $proposed; // Start with proposed as base
+
         $allFields = array_unique(array_merge(
             array_keys($original),
             array_keys($current),
@@ -221,29 +227,75 @@ class BouncerController extends AppController
             return !in_array($field, ['created', 'modified', 'id', '_delete'], true);
         });
 
+        $merger = new ThreeWayMerge();
+
         foreach ($allFields as $field) {
             $origValue = $original[$field] ?? null;
             $currValue = $current[$field] ?? null;
             $propValue = $proposed[$field] ?? null;
 
-            // Conflict: both current and proposed changed from original, differently
+            // Skip if no changes
             $currentChanged = $origValue !== $currValue;
             $proposedChanged = $origValue !== $propValue;
 
-            if ($currentChanged && $proposedChanged && $currValue !== $propValue) {
-                $conflicts[$field] = [
-                    'original' => $origValue,
-                    'current' => $currValue,
-                    'proposed' => $propValue,
-                ];
+            if (!$currentChanged && !$proposedChanged) {
+                continue;
             }
+
+            // If only one side changed, use that change
+            if (!$currentChanged) {
+                $merged[$field] = $propValue;
+
+                continue;
+            }
+            if (!$proposedChanged) {
+                $merged[$field] = $currValue;
+
+                continue;
+            }
+
+            // Both changed - try to merge if strings
+            if ($currValue === $propValue) {
+                // Same change on both sides
+                $merged[$field] = $currValue;
+
+                continue;
+            }
+
+            // Try smart merge for strings
+            if (is_string($origValue) && is_string($currValue) && is_string($propValue)) {
+                $mergeResult = $merger->mergeStrings((string)$origValue, (string)$currValue, (string)$propValue);
+
+                if ($mergeResult['status'] === ThreeWayMerge::MERGED) {
+                    $merged[$field] = $mergeResult['result'];
+                    $autoMerged[$field] = [
+                        'original' => $origValue,
+                        'current' => $currValue,
+                        'proposed' => $propValue,
+                        'result' => $mergeResult['result'],
+                        'currentChanges' => $mergeResult['currentChanges'],
+                        'proposedChanges' => $mergeResult['proposedChanges'],
+                    ];
+
+                    continue;
+                }
+            }
+
+            // True conflict - cannot auto-merge
+            $conflicts[$field] = [
+                'original' => $origValue,
+                'current' => $currValue,
+                'proposed' => $propValue,
+            ];
         }
 
         return [
             'original' => $original,
             'current' => $current,
             'proposed' => $proposed,
+            'merged' => $merged,
             'conflicts' => $conflicts,
+            'autoMerged' => $autoMerged,
             'hasConflicts' => (bool)$conflicts,
         ];
     }

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -102,12 +102,18 @@ class BouncerController extends AppController
                 if ($bouncerRecord->isPending() && $bouncerRecord->canDetectStaleness()) {
                     $currentModified = $currentRecord->get('modified') ?? $currentRecord->get('created');
                     if ($currentModified && $currentModified > $bouncerRecord->original_modified) {
-                        // Stale! Build 3-way diff
+                        // Stale! Build 3-way diff and auto-merge
                         $conflict = $this->buildThreeWayDiff(
                             $bouncerRecord->getOriginalData(),
                             $currentRecord->toArray(),
                             $bouncerRecord->getData(),
                         );
+
+                        // Auto-apply merged data to bouncer record for display
+                        // This updates in-memory only, not saved to database yet
+                        if (!empty($conflict['merged'])) {
+                            $bouncerRecord->setMergedData($conflict['merged']);
+                        }
                     }
                 }
             } catch (Exception $e) {

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -90,18 +90,161 @@ class BouncerController extends AppController
 
         // Get the current published version for comparison (if edit)
         $currentRecord = null;
+        $conflict = null;
+
         if ($bouncerRecord->isEditProposal()) {
             try {
                 $sourceTable = $this->fetchTable($bouncerRecord->source);
                 $currentRecord = $sourceTable->get($bouncerRecord->primary_key);
+
+                // Check for staleness on-demand (only for pending records)
+                if ($bouncerRecord->isPending() && $bouncerRecord->canDetectStaleness()) {
+                    $currentModified = $currentRecord->get('modified') ?? $currentRecord->get('created');
+                    if ($currentModified && $currentModified > $bouncerRecord->original_modified) {
+                        // Stale! Build 3-way diff
+                        $conflict = $this->buildThreeWayDiff(
+                            $bouncerRecord->getOriginalData(),
+                            $currentRecord->toArray(),
+                            $bouncerRecord->getData(),
+                        );
+                    }
+                }
             } catch (Exception $e) {
                 $this->Flash->warning('The original record no longer exists.');
             }
         }
 
-        $this->set(compact('bouncerRecord', 'currentRecord'));
+        $this->set(compact('bouncerRecord', 'currentRecord', 'conflict'));
 
         return null;
+    }
+
+    /**
+     * Resolve method - 3-way merge interface for conflicts
+     *
+     * @param int|null $id Bouncer Record id.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function resolve(?int $id = null)
+    {
+        $bouncerRecord = $this->BouncerRecords->get($id);
+
+        if (!$bouncerRecord->isPending()) {
+            $this->Flash->error('This record has already been processed.');
+
+            return $this->redirect(['action' => 'index']);
+        }
+
+        if (!$bouncerRecord->isEditProposal()) {
+            $this->Flash->warning('Conflict resolution is only available for edit proposals.');
+
+            return $this->redirect(['action' => 'view', $id]);
+        }
+
+        // Load current record and check for conflict
+        try {
+            $sourceTable = $this->fetchTable($bouncerRecord->source);
+            $currentRecord = $sourceTable->get($bouncerRecord->primary_key);
+        } catch (Exception $e) {
+            $this->Flash->error('The original record no longer exists.');
+
+            return $this->redirect(['action' => 'index']);
+        }
+
+        // Check if there's actually a conflict
+        $hasConflict = false;
+        if ($bouncerRecord->canDetectStaleness()) {
+            $currentModified = $currentRecord->get('modified') ?? $currentRecord->get('created');
+            $hasConflict = $currentModified && $currentModified > $bouncerRecord->original_modified;
+        }
+
+        if (!$hasConflict) {
+            $this->Flash->info('No conflict detected. You can proceed with normal approval.');
+
+            return $this->redirect(['action' => 'view', $id]);
+        }
+
+        $conflict = $this->buildThreeWayDiff(
+            $bouncerRecord->getOriginalData(),
+            $currentRecord->toArray(),
+            $bouncerRecord->getData(),
+        );
+
+        if ($this->request->is(['post', 'put'])) {
+            $mergedData = $this->request->getData('merged');
+
+            if ($mergedData) {
+                // Update bouncer record with merged data
+                $bouncerRecord->data = json_encode($mergedData, JSON_THROW_ON_ERROR);
+                // Update original_modified to current time to mark conflict as resolved
+                $bouncerRecord->original_modified = $currentRecord->get('modified') ?? $currentRecord->get('created');
+                // Update original_data to current state
+                $bouncerRecord->original_data = json_encode($currentRecord->toArray(), JSON_THROW_ON_ERROR);
+
+                if ($this->BouncerRecords->save($bouncerRecord)) {
+                    $this->Flash->success('Conflict resolved. Ready for final approval.');
+
+                    return $this->redirect(['action' => 'view', $id]);
+                }
+
+                $this->Flash->error('Failed to save merged changes.');
+            }
+        }
+
+        $this->set(compact('bouncerRecord', 'currentRecord', 'conflict'));
+
+        return null;
+    }
+
+    /**
+     * Build a 3-way diff for conflict resolution.
+     *
+     * @param array<string, mixed> $original Original data when draft was created
+     * @param array<string, mixed> $current Current live data
+     * @param array<string, mixed> $proposed Proposed changes in draft
+     *
+     * @return array{original: array, current: array, proposed: array, conflicts: array<string, array>, hasConflicts: bool}
+     */
+    protected function buildThreeWayDiff(array $original, array $current, array $proposed): array
+    {
+        $conflicts = [];
+        $allFields = array_unique(array_merge(
+            array_keys($original),
+            array_keys($current),
+            array_keys($proposed),
+        ));
+
+        // Filter out internal fields
+        $allFields = array_filter($allFields, function ($field) {
+            return !in_array($field, ['created', 'modified', 'id', '_delete'], true);
+        });
+
+        foreach ($allFields as $field) {
+            $origValue = $original[$field] ?? null;
+            $currValue = $current[$field] ?? null;
+            $propValue = $proposed[$field] ?? null;
+
+            // Conflict: both current and proposed changed from original, differently
+            $currentChanged = $origValue !== $currValue;
+            $proposedChanged = $origValue !== $propValue;
+
+            if ($currentChanged && $proposedChanged && $currValue !== $propValue) {
+                $conflicts[$field] = [
+                    'original' => $origValue,
+                    'current' => $currValue,
+                    'proposed' => $propValue,
+                ];
+            }
+        }
+
+        return [
+            'original' => $original,
+            'current' => $current,
+            'proposed' => $proposed,
+            'conflicts' => $conflicts,
+            'hasConflicts' => (bool)$conflicts,
+        ];
     }
 
     /**

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -335,6 +335,35 @@ class BouncerController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
+        // Auto-merge stale records before approval
+        if ($bouncerRecord->isEditProposal() && $bouncerRecord->canDetectStaleness()) {
+            try {
+                $sourceTable = $this->fetchTable($bouncerRecord->source);
+                $currentRecord = $sourceTable->get($bouncerRecord->primary_key);
+                $currentModified = $currentRecord->get('modified') ?? $currentRecord->get('created');
+
+                if ($currentModified && $currentModified > $bouncerRecord->original_modified) {
+                    // Record is stale - auto-merge before applying
+                    $conflict = $this->buildThreeWayDiff(
+                        $bouncerRecord->getOriginalData(),
+                        $currentRecord->toArray(),
+                        $bouncerRecord->getData(),
+                    );
+
+                    if ($conflict['hasConflicts']) {
+                        $this->Flash->error('This record has unresolved conflicts. Please resolve them first.');
+
+                        return $this->redirect(['action' => 'resolve', $id]);
+                    }
+
+                    // Update bouncer record with merged data
+                    $bouncerRecord->data = json_encode($conflict['merged'], JSON_THROW_ON_ERROR);
+                }
+            } catch (Exception $e) {
+                // Source record no longer exists - continue with approval (will fail gracefully)
+            }
+        }
+
         $connection = $this->BouncerRecords->getConnection();
 
         try {

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -184,11 +184,11 @@ class BouncerController extends AppController
 
             if ($mergedData) {
                 // Update bouncer record with merged data
-                $bouncerRecord->data = json_encode($mergedData, JSON_THROW_ON_ERROR);
+                $bouncerRecord->data = json_encode($mergedData, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
                 // Update original_modified to current time to mark conflict as resolved
                 $bouncerRecord->original_modified = $currentRecord->get('modified') ?? $currentRecord->get('created');
                 // Update original_data to current state
-                $bouncerRecord->original_data = json_encode($currentRecord->toArray(), JSON_THROW_ON_ERROR);
+                $bouncerRecord->original_data = json_encode($currentRecord->toArray(), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
 
                 if ($this->BouncerRecords->save($bouncerRecord)) {
                     $this->Flash->success('Conflict resolved. Ready for final approval.');
@@ -357,7 +357,7 @@ class BouncerController extends AppController
                     }
 
                     // Update bouncer record with merged data
-                    $bouncerRecord->data = json_encode($conflict['merged'], JSON_THROW_ON_ERROR);
+                    $bouncerRecord->data = json_encode($conflict['merged'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
                 }
             } catch (Exception $e) {
                 // Source record no longer exists - continue with approval (will fail gracefully)

--- a/src/Lib/DiffLib.php
+++ b/src/Lib/DiffLib.php
@@ -381,6 +381,13 @@ class DiffLib
     }
 
     /**
+     * Maximum characters for character-level diff (to avoid memory exhaustion).
+     *
+     * @var int
+     */
+    protected int $maxCharDiffLength = 1000;
+
+    /**
      * Compute character-level diff between two lines.
      *
      * @param string $oldLine
@@ -390,6 +397,18 @@ class DiffLib
      */
     protected function computeCharDiff(string $oldLine, string $newLine): array
     {
+        $oldLen = mb_strlen($oldLine);
+        $newLen = mb_strlen($newLine);
+
+        // Skip character-level diff for very long strings to avoid memory exhaustion
+        // LCS algorithm uses O(m*n) memory which can be massive for large strings
+        if ($oldLen > $this->maxCharDiffLength || $newLen > $this->maxCharDiffLength) {
+            return [
+                '<del>' . htmlspecialchars($oldLine) . '</del>',
+                '<ins>' . htmlspecialchars($newLine) . '</ins>',
+            ];
+        }
+
         $oldChars = preg_split('//u', $oldLine, -1, PREG_SPLIT_NO_EMPTY) ?: [];
         $newChars = preg_split('//u', $newLine, -1, PREG_SPLIT_NO_EMPTY) ?: [];
 

--- a/src/Lib/ThreeWayMerge.php
+++ b/src/Lib/ThreeWayMerge.php
@@ -406,4 +406,111 @@ class ThreeWayMerge
 
         return mb_substr($str, 0, $maxLen - 3) . '...';
     }
+
+    /**
+     * Perform a 3-way merge on arrays of data (entity fields).
+     *
+     * This merges field-by-field, using string merging for text fields
+     * when both sides have changed.
+     *
+     * @param array<string, mixed> $original The original data when draft was created
+     * @param array<string, mixed> $current The current live data
+     * @param array<string, mixed> $proposed The proposed changes
+     * @param array<string> $skipFields Fields to skip during merge (e.g., 'id', 'created', 'modified')
+     *
+     * @return array{merged: array<string, mixed>, conflicts: array<string, array>, autoMerged: array<string, array>, hasConflicts: bool}
+     */
+    public function mergeArrays(
+        array $original,
+        array $current,
+        array $proposed,
+        array $skipFields = ['id', 'created', 'modified', '_delete'],
+    ): array {
+        $conflicts = [];
+        $autoMerged = [];
+        $merged = $proposed;
+
+        $allFields = array_unique(array_merge(
+            array_keys($original),
+            array_keys($current),
+            array_keys($proposed),
+        ));
+
+        // Filter out skip fields
+        $allFields = array_filter($allFields, function ($field) use ($skipFields) {
+            return !in_array($field, $skipFields, true);
+        });
+
+        foreach ($allFields as $field) {
+            $origValue = $original[$field] ?? null;
+            $currValue = $current[$field] ?? null;
+            $propValue = $proposed[$field] ?? null;
+
+            // Skip fields not in the original proposal
+            if (!array_key_exists($field, $proposed)) {
+                continue;
+            }
+
+            // Skip if no changes
+            $currentChanged = $origValue !== $currValue;
+            $proposedChanged = $origValue !== $propValue;
+
+            if (!$currentChanged && !$proposedChanged) {
+                continue;
+            }
+
+            // If only one side changed, use that change
+            if (!$currentChanged) {
+                // Only proposed changed - keep proposed value (already in $merged)
+                continue;
+            }
+            if (!$proposedChanged) {
+                // Only current changed - use current value
+                $merged[$field] = $currValue;
+                $autoMerged[$field] = [
+                    'original' => $origValue,
+                    'current' => $currValue,
+                    'proposed' => $propValue,
+                    'merged' => $currValue,
+                    'reason' => 'current_only',
+                ];
+
+                continue;
+            }
+
+            // Both sides changed - attempt text merge for strings
+            if (is_string($origValue) && is_string($currValue) && is_string($propValue)) {
+                $mergeResult = $this->mergeStrings($origValue, $currValue, $propValue);
+
+                if ($mergeResult['status'] === self::MERGED) {
+                    $merged[$field] = $mergeResult['result'];
+                    $autoMerged[$field] = [
+                        'original' => $origValue,
+                        'current' => $currValue,
+                        'proposed' => $propValue,
+                        'merged' => $mergeResult['result'],
+                        'reason' => 'text_merge',
+                    ];
+
+                    continue;
+                }
+            }
+
+            // Real conflict - both changed to different values
+            $conflicts[$field] = [
+                'original' => $origValue,
+                'current' => $currValue,
+                'proposed' => $propValue,
+            ];
+            // Keep proposed value as default for conflicts
+            $merged[$field] = $propValue;
+        }
+
+        return [
+            'merged' => $merged,
+            'conflicts' => $conflicts,
+            'autoMerged' => $autoMerged,
+            'hasConflicts' => (bool)$conflicts,
+        ];
+    }
 }

--- a/src/Lib/ThreeWayMerge.php
+++ b/src/Lib/ThreeWayMerge.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Lib;
+
+/**
+ * Three-way merge implementation for conflict resolution.
+ *
+ * Attempts to automatically merge changes from two divergent versions
+ * based on a common ancestor (original).
+ */
+class ThreeWayMerge
+{
+    /**
+     * Merge result indicating successful auto-merge.
+     *
+     * @var string
+     */
+    public const MERGED = 'merged';
+
+    /**
+     * Merge result indicating a conflict that requires manual resolution.
+     *
+     * @var string
+     */
+    public const CONFLICT = 'conflict';
+
+    /**
+     * Perform a 3-way merge on string values.
+     *
+     * @param string $original The common ancestor
+     * @param string $current The current live version
+     * @param string $proposed The proposed changes
+     *
+     * @return array{status: string, result: string, currentChanges: array, proposedChanges: array}
+     */
+    public function mergeStrings(string $original, string $current, string $proposed): array
+    {
+        // If current equals original, just take proposed
+        if ($current === $original) {
+            return [
+                'status' => self::MERGED,
+                'result' => $proposed,
+                'currentChanges' => [],
+                'proposedChanges' => $this->describeChanges($original, $proposed),
+            ];
+        }
+
+        // If proposed equals original, just take current
+        if ($proposed === $original) {
+            return [
+                'status' => self::MERGED,
+                'result' => $current,
+                'currentChanges' => $this->describeChanges($original, $current),
+                'proposedChanges' => [],
+            ];
+        }
+
+        // If current and proposed are the same, no conflict
+        if ($current === $proposed) {
+            return [
+                'status' => self::MERGED,
+                'result' => $current,
+                'currentChanges' => $this->describeChanges($original, $current),
+                'proposedChanges' => $this->describeChanges($original, $proposed),
+            ];
+        }
+
+        // Try character-level 3-way merge
+        return $this->mergeCharacters($original, $current, $proposed);
+    }
+
+    /**
+     * Perform character-level 3-way merge using fallback approach.
+     *
+     * @param string $original
+     * @param string $current
+     * @param string $proposed
+     *
+     * @return array{status: string, result: string, currentChanges: array, proposedChanges: array}
+     */
+    protected function mergeCharacters(string $original, string $current, string $proposed): array
+    {
+        // Use the simpler fallback merge which handles non-overlapping changes
+        return $this->fallbackMerge($original, $current, $proposed);
+    }
+
+    /**
+     * Fallback merge using a simpler diff-patch approach.
+     *
+     * @param string $original
+     * @param string $current
+     * @param string $proposed
+     *
+     * @return array{status: string, result: string, currentChanges: array, proposedChanges: array}
+     */
+    protected function fallbackMerge(string $original, string $current, string $proposed): array
+    {
+        // Find where current diverges from original (from start)
+        $currPrefixLen = $this->commonPrefixLength($original, $current);
+        // Find where current diverges from original (from end)
+        $currSuffixLen = $this->commonSuffixLength($original, $current);
+
+        // Same for proposed
+        $propPrefixLen = $this->commonPrefixLength($original, $proposed);
+        $propSuffixLen = $this->commonSuffixLength($original, $proposed);
+
+        $origLen = mb_strlen($original);
+        $currLen = mb_strlen($current);
+        $propLen = mb_strlen($proposed);
+
+        // Avoid overlap - check against both strings
+        $currMinLen = min($origLen, $currLen);
+        if ($currPrefixLen + $currSuffixLen > $currMinLen) {
+            $currSuffixLen = $currMinLen - $currPrefixLen;
+        }
+        $propMinLen = min($origLen, $propLen);
+        if ($propPrefixLen + $propSuffixLen > $propMinLen) {
+            $propSuffixLen = $propMinLen - $propPrefixLen;
+        }
+
+        // Current change region in original: [currPrefixLen, origLen - currSuffixLen)
+        // Proposed change region in original: [propPrefixLen, origLen - propSuffixLen)
+        $currChangeStart = $currPrefixLen;
+        $currChangeEnd = $origLen - $currSuffixLen;
+        $propChangeStart = $propPrefixLen;
+        $propChangeEnd = $origLen - $propSuffixLen;
+
+        // Special case: if both sides insert at the same position (same change region),
+        // they conflict unless they insert the same content
+        if ($currChangeStart === $propChangeStart && $currChangeEnd === $propChangeEnd) {
+            // Both changed the same region - this is a conflict
+            return [
+                'status' => self::CONFLICT,
+                'result' => $proposed,
+                'currentChanges' => $this->describeChanges($original, $current),
+                'proposedChanges' => $this->describeChanges($original, $proposed),
+            ];
+        }
+
+        // Check if regions overlap
+        if ($currChangeEnd <= $propChangeStart) {
+            // Current changes before proposed - apply current first, then proposed
+            $result = $this->applySequentialChanges($original, $current, $proposed, $currChangeStart, $currChangeEnd, $propChangeStart, $propChangeEnd);
+
+            return [
+                'status' => self::MERGED,
+                'result' => $result,
+                'currentChanges' => $this->describeChanges($original, $current),
+                'proposedChanges' => $this->describeChanges($original, $proposed),
+            ];
+        }
+
+        if ($propChangeEnd <= $currChangeStart) {
+            // Proposed changes before current - apply proposed first, then current
+            $result = $this->applySequentialChanges($original, $proposed, $current, $propChangeStart, $propChangeEnd, $currChangeStart, $currChangeEnd);
+
+            return [
+                'status' => self::MERGED,
+                'result' => $result,
+                'currentChanges' => $this->describeChanges($original, $current),
+                'proposedChanges' => $this->describeChanges($original, $proposed),
+            ];
+        }
+
+        // Regions overlap - true conflict
+        return [
+            'status' => self::CONFLICT,
+            'result' => $proposed,
+            'currentChanges' => $this->describeChanges($original, $current),
+            'proposedChanges' => $this->describeChanges($original, $proposed),
+        ];
+    }
+
+    /**
+     * Apply two non-overlapping changes sequentially.
+     *
+     * @param string $original
+     * @param string $first Version with earlier change
+     * @param string $second Version with later change
+     * @param int $firstStart Start of first change in original
+     * @param int $firstEnd End of first change in original
+     * @param int $secondStart Start of second change in original
+     * @param int $secondEnd End of second change in original
+     *
+     * @return string
+     */
+    protected function applySequentialChanges(
+        string $original,
+        string $first,
+        string $second,
+        int $firstStart,
+        int $firstEnd,
+        int $secondStart,
+        int $secondEnd,
+    ): string {
+        $origLen = mb_strlen($original);
+        $firstLen = mb_strlen($first);
+        $secondLen = mb_strlen($second);
+
+        // Calculate the suffix length in original for each version
+        $firstSuffixLen = $origLen - $firstEnd;
+        $secondSuffixLen = $origLen - $secondEnd;
+
+        // Extract the replacement from first version
+        // It's what's between the prefix and suffix in the first string
+        $firstReplacementLen = $firstLen - $firstStart - $firstSuffixLen;
+        $firstReplacement = $firstReplacementLen > 0 ? mb_substr($first, $firstStart, $firstReplacementLen) : '';
+
+        // Extract the replacement from second version
+        $secondReplacementLen = $secondLen - $secondStart - $secondSuffixLen;
+        $secondReplacement = $secondReplacementLen > 0 ? mb_substr($second, $secondStart, $secondReplacementLen) : '';
+
+        // Build result: prefix + first replacement + middle + second replacement + suffix
+        $result = mb_substr($original, 0, $firstStart);
+        $result .= $firstReplacement;
+        $result .= mb_substr($original, $firstEnd, $secondStart - $firstEnd);
+        $result .= $secondReplacement;
+        $result .= mb_substr($original, $secondEnd);
+
+        return $result;
+    }
+
+    /**
+     * Get length of common prefix between two strings.
+     *
+     * @param string $a
+     * @param string $b
+     *
+     * @return int
+     */
+    protected function commonPrefixLength(string $a, string $b): int
+    {
+        $aChars = $this->toChars($a);
+        $bChars = $this->toChars($b);
+        $len = min(count($aChars), count($bChars));
+
+        for ($i = 0; $i < $len; $i++) {
+            if ($aChars[$i] !== $bChars[$i]) {
+                return $i;
+            }
+        }
+
+        return $len;
+    }
+
+    /**
+     * Get length of common suffix between two strings.
+     *
+     * @param string $a
+     * @param string $b
+     *
+     * @return int
+     */
+    protected function commonSuffixLength(string $a, string $b): int
+    {
+        $aChars = $this->toChars($a);
+        $bChars = $this->toChars($b);
+        $aLen = count($aChars);
+        $bLen = count($bChars);
+        $len = min($aLen, $bLen);
+
+        for ($i = 0; $i < $len; $i++) {
+            if ($aChars[$aLen - 1 - $i] !== $bChars[$bLen - 1 - $i]) {
+                return $i;
+            }
+        }
+
+        return $len;
+    }
+
+    /**
+     * Convert string to array of characters (UTF-8 safe).
+     *
+     * @param string $str
+     *
+     * @return array<string>
+     */
+    protected function toChars(string $str): array
+    {
+        return preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+    }
+
+    /**
+     * Find common prefix of multiple strings.
+     *
+     * @param array<string> $strings
+     *
+     * @return string
+     */
+    protected function commonPrefix(array $strings): string
+    {
+        if (!$strings) {
+            return '';
+        }
+
+        $first = $this->toChars($strings[0]);
+        $prefix = [];
+        $firstLen = count($first);
+
+        for ($i = 0; $i < $firstLen; $i++) {
+            $char = $first[$i];
+            foreach ($strings as $str) {
+                $chars = $this->toChars($str);
+                if (!isset($chars[$i]) || $chars[$i] !== $char) {
+                    return implode('', $prefix);
+                }
+            }
+            $prefix[] = $char;
+        }
+
+        return implode('', $prefix);
+    }
+
+    /**
+     * Find common suffix of multiple strings.
+     *
+     * @param array<string> $strings
+     *
+     * @return string
+     */
+    protected function commonSuffix(array $strings): string
+    {
+        if (!$strings) {
+            return '';
+        }
+
+        $reversed = array_map(fn ($s) => $this->reverseString($s), $strings);
+        $prefix = $this->commonPrefix($reversed);
+
+        return $this->reverseString($prefix);
+    }
+
+    /**
+     * Reverse a UTF-8 string.
+     *
+     * @param string $str
+     *
+     * @return string
+     */
+    protected function reverseString(string $str): string
+    {
+        $chars = $this->toChars($str);
+
+        return implode('', array_reverse($chars));
+    }
+
+    /**
+     * Describe the changes between two strings.
+     *
+     * @param string $from
+     * @param string $to
+     *
+     * @return array<string>
+     */
+    protected function describeChanges(string $from, string $to): array
+    {
+        if ($from === $to) {
+            return [];
+        }
+
+        $changes = [];
+
+        // Find common prefix/suffix to identify what changed
+        $prefix = $this->commonPrefix([$from, $to]);
+        $suffix = $this->commonSuffix([$from, $to]);
+
+        $prefixLen = mb_strlen($prefix);
+        $suffixLen = mb_strlen($suffix);
+        $fromLen = mb_strlen($from);
+        $toLen = mb_strlen($to);
+
+        // Avoid overlap
+        if ($prefixLen + $suffixLen > min($fromLen, $toLen)) {
+            $suffixLen = max(0, min($fromLen, $toLen) - $prefixLen);
+        }
+
+        $fromMiddle = mb_substr($from, $prefixLen, $fromLen - $prefixLen - $suffixLen);
+        $toMiddle = mb_substr($to, $prefixLen, $toLen - $prefixLen - $suffixLen);
+
+        if ($fromMiddle === '' && $toMiddle !== '') {
+            $changes[] = sprintf('Added "%s"', $this->truncate($toMiddle, 30));
+        } elseif ($fromMiddle !== '' && $toMiddle === '') {
+            $changes[] = sprintf('Removed "%s"', $this->truncate($fromMiddle, 30));
+        } elseif ($fromMiddle !== $toMiddle) {
+            $changes[] = sprintf('Changed "%s" → "%s"', $this->truncate($fromMiddle, 20), $this->truncate($toMiddle, 20));
+        }
+
+        return $changes;
+    }
+
+    /**
+     * Truncate a string with ellipsis.
+     *
+     * @param string $str
+     * @param int $maxLen
+     *
+     * @return string
+     */
+    protected function truncate(string $str, int $maxLen): string
+    {
+        if (mb_strlen($str) <= $maxLen) {
+            return $str;
+        }
+
+        return mb_substr($str, 0, $maxLen - 3) . '...';
+    }
+}

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -246,10 +246,13 @@ class BouncerBehavior extends Behavior
         $data = $this->serializeEntity($entity);
         $originalData = null;
 
+        $originalModified = null;
         if (!$isNew) {
             // For edits, store the current state as original
             $original = $this->_table->get($primaryKey);
             $originalData = $this->serializeEntity($original);
+            // Capture modification timestamp for conflict detection
+            $originalModified = $original->get('modified') ?? $original->get('created');
         }
 
         $note = $this->getNote($options);
@@ -261,7 +264,7 @@ class BouncerBehavior extends Behavior
 
             if ($isExistingDelete) {
                 // Existing draft is a delete, create new edit draft (will be superseded below)
-                $bouncerRecord = $bouncerTable->newEntity([
+                $bouncerData = [
                     'source' => $source,
                     'primary_key' => $primaryKey,
                     'user_id' => $userId,
@@ -269,7 +272,11 @@ class BouncerBehavior extends Behavior
                     'data' => $data,
                     'original_data' => $originalData,
                     'note' => $note,
-                ]);
+                ];
+                if ($originalModified !== null) {
+                    $bouncerData['original_modified'] = $originalModified;
+                }
+                $bouncerRecord = $bouncerTable->newEntity($bouncerData);
                 $bouncerRecord = $bouncerTable->save($bouncerRecord, ['atomic' => false]);
             } else {
                 // Check if the new data matches the original data (effectively reverted)
@@ -310,6 +317,9 @@ class BouncerBehavior extends Behavior
                     if ($note !== null) {
                         $patchData['note'] = $note;
                     }
+                    if ($originalModified !== null) {
+                        $patchData['original_modified'] = $originalModified;
+                    }
                     $bouncerTable->patchEntity($existingDraft, $patchData);
                     $bouncerRecord = $bouncerTable->save($existingDraft, ['atomic' => false]);
                 }
@@ -340,7 +350,7 @@ class BouncerBehavior extends Behavior
             }
 
             // Create new draft
-            $bouncerRecord = $bouncerTable->newEntity([
+            $bouncerData = [
                 'source' => $source,
                 'primary_key' => $primaryKey,
                 'user_id' => $userId,
@@ -348,7 +358,11 @@ class BouncerBehavior extends Behavior
                 'data' => $data,
                 'original_data' => $originalData,
                 'note' => $note,
-            ]);
+            ];
+            if ($originalModified !== null) {
+                $bouncerData['original_modified'] = $originalModified;
+            }
+            $bouncerRecord = $bouncerTable->newEntity($bouncerData);
             $bouncerRecord = $bouncerTable->save($bouncerRecord, ['atomic' => false]);
         }
 
@@ -416,6 +430,8 @@ class BouncerBehavior extends Behavior
         $originalData = json_encode($entity->toArray());
         $data = json_encode(['_delete' => true]); // Mark as deletion
         $note = $this->getNote($options);
+        // Capture modification timestamp for conflict detection
+        $originalModified = $entity->get('modified') ?? $entity->get('created');
 
         if ($existingDraft) {
             // Check if existing draft is also a delete (same type)
@@ -431,11 +447,14 @@ class BouncerBehavior extends Behavior
                 if ($note !== null) {
                     $patchData['note'] = $note;
                 }
+                if ($originalModified !== null) {
+                    $patchData['original_modified'] = $originalModified;
+                }
                 $bouncerTable->patchEntity($existingDraft, $patchData);
                 $bouncerRecord = $bouncerTable->save($existingDraft, ['atomic' => false]);
             } else {
                 // Existing draft is an edit, create new delete draft (will be superseded below)
-                $bouncerRecord = $bouncerTable->newEntity([
+                $bouncerData = [
                     'source' => $source,
                     'primary_key' => $primaryKey,
                     'user_id' => $userId,
@@ -443,12 +462,16 @@ class BouncerBehavior extends Behavior
                     'data' => $data,
                     'original_data' => $originalData,
                     'note' => $note,
-                ]);
+                ];
+                if ($originalModified !== null) {
+                    $bouncerData['original_modified'] = $originalModified;
+                }
+                $bouncerRecord = $bouncerTable->newEntity($bouncerData);
                 $bouncerRecord = $bouncerTable->save($bouncerRecord, ['atomic' => false]);
             }
         } else {
             // Create new delete bouncer record
-            $bouncerRecord = $bouncerTable->newEntity([
+            $bouncerData = [
                 'source' => $source,
                 'primary_key' => $primaryKey,
                 'user_id' => $userId,
@@ -456,7 +479,11 @@ class BouncerBehavior extends Behavior
                 'data' => $data,
                 'original_data' => $originalData,
                 'note' => $note,
-            ]);
+            ];
+            if ($originalModified !== null) {
+                $bouncerData['original_modified'] = $originalModified;
+            }
+            $bouncerRecord = $bouncerTable->newEntity($bouncerData);
             $bouncerRecord = $bouncerTable->save($bouncerRecord, ['atomic' => false]);
         }
 

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -805,7 +805,8 @@ class BouncerBehavior extends Behavior
      */
     public function applyApprovedChanges($bouncerRecord, array $options = [])
     {
-        $data = $bouncerRecord->getData();
+        // Use merged data if available (for 3-way merge scenarios), otherwise use original data
+        $data = $bouncerRecord->getMergedData();
 
         // Check if this is a delete operation
         if (isset($data['_delete']) && $data['_delete']) {

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bouncer\Model\Behavior;
 
 use ArrayObject;
+use Bouncer\Lib\ThreeWayMerge;
 use Bouncer\Model\Entity\BouncerRecord;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
@@ -809,6 +810,15 @@ class BouncerBehavior extends Behavior
     /**
      * Apply approved bouncer record changes to the actual table.
      *
+     * For edit proposals on stale records (where the source record has been modified
+     * since the proposal was created), this method automatically performs a 3-way merge
+     * to preserve both the owner's changes and the proposal's changes when possible.
+     *
+     * Options:
+     * - `autoMerge`: bool (default: true) - Whether to automatically perform 3-way merge for stale records.
+     *   Set to false if you want to handle merging manually before calling this method.
+     * - `skipFields`: array - Fields to skip during merge (default: ['id', 'created', 'modified', '_delete'])
+     *
      * @param \Bouncer\Model\Entity\BouncerRecord $bouncerRecord Bouncer record
      * @param array<string, mixed> $options Save options
      *
@@ -816,6 +826,38 @@ class BouncerBehavior extends Behavior
      */
     public function applyApprovedChanges($bouncerRecord, array $options = [])
     {
+        $autoMerge = $options['autoMerge'] ?? true;
+        unset($options['autoMerge']);
+
+        // Auto-merge stale edit proposals if not already merged
+        if (
+            $autoMerge
+            && !$bouncerRecord->hasMergedData()
+            && $bouncerRecord->isEditProposal()
+            && $bouncerRecord->canDetectStaleness()
+        ) {
+            $currentRecord = $this->_table->get($bouncerRecord->primary_key);
+            $currentModified = $currentRecord->get('modified') ?? $currentRecord->get('created');
+
+            if ($currentModified && $currentModified > $bouncerRecord->original_modified) {
+                // Record is stale - perform 3-way merge
+                $skipFields = $options['skipFields'] ?? ['id', 'created', 'modified', '_delete'];
+                unset($options['skipFields']);
+
+                $merger = new ThreeWayMerge();
+                $mergeResult = $merger->mergeArrays(
+                    $bouncerRecord->getOriginalData(),
+                    $currentRecord->toArray(),
+                    $bouncerRecord->getData(),
+                    $skipFields,
+                );
+
+                // Apply merged data (even if there are conflicts, we use the merged result
+                // which defaults to proposed values for conflicting fields)
+                $bouncerRecord->setMergedData($mergeResult['merged']);
+            }
+        }
+
         // Use merged data if available (for 3-way merge scenarios), otherwise use original data
         $data = $bouncerRecord->getMergedData();
 

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -24,6 +24,13 @@ class BouncerBehavior extends Behavior
     use LocatorAwareTrait;
 
     /**
+     * Default JSON encoding flags for storing data.
+     *
+     * @var int
+     */
+    public const JSON_FLAGS = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+
+    /**
      * Default configuration.
      *
      * @var array<string, mixed>
@@ -427,8 +434,8 @@ class BouncerBehavior extends Behavior
         )->first();
 
         // Store current entity state as original_data
-        $originalData = json_encode($entity->toArray());
-        $data = json_encode(['_delete' => true]); // Mark as deletion
+        $originalData = json_encode($entity->toArray(), self::JSON_FLAGS);
+        $data = json_encode(['_delete' => true], self::JSON_FLAGS); // Mark as deletion
         $note = $this->getNote($options);
         // Capture modification timestamp for conflict detection
         $originalModified = $entity->get('modified') ?? $entity->get('created');
@@ -540,7 +547,7 @@ class BouncerBehavior extends Behavior
         // Remove internal fields
         unset($data['created'], $data['modified']);
 
-        $encoded = json_encode($data);
+        $encoded = json_encode($data, self::JSON_FLAGS);
         if ($encoded === false) {
             throw new RuntimeException('Failed to encode entity data');
         }

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -26,9 +26,13 @@ class BouncerBehavior extends Behavior
     /**
      * Default JSON encoding flags for storing data.
      *
+     * - JSON_UNESCAPED_UNICODE: Store UTF-8 characters directly (ö instead of \u00f6)
+     * - JSON_UNESCAPED_SLASHES: Don't escape forward slashes
+     * - JSON_PRESERVE_ZERO_FRACTION: Keep 10.0 as 10.0 instead of 10
+     *
      * @var int
      */
-    public const JSON_FLAGS = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+    public const JSON_FLAGS = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION;
 
     /**
      * Default configuration.

--- a/src/Model/Entity/BouncerRecord.php
+++ b/src/Model/Entity/BouncerRecord.php
@@ -18,6 +18,7 @@ use Cake\ORM\Entity;
  * @property string $data
  * @property string|null $original_data
  * @property string|null $note
+ * @property \Cake\I18n\DateTime|null $original_modified
  * @property string|null $reason
  * @property \Cake\I18n\DateTime|null $reviewed
  * @property \Cake\I18n\DateTime|null $created
@@ -39,6 +40,7 @@ class BouncerRecord extends Entity
         'data' => true,
         'original_data' => true,
         'note' => true,
+        'original_modified' => true,
         'reason' => true,
         'reviewed' => true,
         'created' => true,
@@ -133,5 +135,28 @@ class BouncerRecord extends Entity
         $data = $this->getData();
 
         return isset($data['_delete']) && $data['_delete'] === true;
+    }
+
+    /**
+     * Check if original_modified field is available (migration was run).
+     *
+     * @return bool
+     */
+    public function hasOriginalModified(): bool
+    {
+        return $this->has('original_modified');
+    }
+
+    /**
+     * Check if this draft may be stale (source record could have been modified).
+     *
+     * This only indicates the field is set - actual staleness must be checked
+     * by comparing with the current source record.
+     *
+     * @return bool
+     */
+    public function canDetectStaleness(): bool
+    {
+        return $this->hasOriginalModified() && $this->original_modified !== null;
     }
 }

--- a/src/Model/Entity/BouncerRecord.php
+++ b/src/Model/Entity/BouncerRecord.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bouncer\Model\Entity;
 
+use Bouncer\Lib\ThreeWayMerge;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Entity;
 
 /**
@@ -195,5 +197,50 @@ class BouncerRecord extends Entity
     public function canDetectStaleness(): bool
     {
         return $this->hasOriginalModified() && $this->original_modified !== null;
+    }
+
+    /**
+     * Check if this draft is stale (source record was modified after this draft was created).
+     *
+     * @param \Cake\Datasource\EntityInterface $currentEntity The current source entity
+     *
+     * @return bool
+     */
+    public function isStale(EntityInterface $currentEntity): bool
+    {
+        if (!$this->canDetectStaleness()) {
+            return false;
+        }
+
+        $currentModified = $currentEntity->get('modified') ?? $currentEntity->get('created');
+
+        return $currentModified && $currentModified > $this->original_modified;
+    }
+
+    /**
+     * Build 3-way merge result comparing this draft against the current entity state.
+     *
+     * Returns null if the draft is not stale (no merge needed).
+     * Otherwise returns the merge result with merged data, conflicts, etc.
+     *
+     * @param \Cake\Datasource\EntityInterface $currentEntity The current source entity
+     * @param array<string> $skipFields Fields to skip during merge
+     *
+     * @return array{merged: array<string, mixed>, conflicts: array<string, array>, autoMerged: array<string, array>, hasConflicts: bool}|null
+     */
+    public function buildMergeResult(EntityInterface $currentEntity, array $skipFields = ['id', 'created', 'modified', '_delete']): ?array
+    {
+        if (!$this->isStale($currentEntity)) {
+            return null;
+        }
+
+        $merger = new ThreeWayMerge();
+
+        return $merger->mergeArrays(
+            $this->getOriginalData(),
+            $currentEntity->toArray(),
+            $this->getData(),
+            $skipFields,
+        );
     }
 }

--- a/src/Model/Entity/BouncerRecord.php
+++ b/src/Model/Entity/BouncerRecord.php
@@ -138,6 +138,11 @@ class BouncerRecord extends Entity
     }
 
     /**
+     * @var array<string, mixed>|null
+     */
+    protected ?array $_mergedData = null;
+
+    /**
      * Check if original_modified field is available (migration was run).
      *
      * @return bool
@@ -145,6 +150,38 @@ class BouncerRecord extends Entity
     public function hasOriginalModified(): bool
     {
         return $this->has('original_modified');
+    }
+
+    /**
+     * Set merged data for display purposes (not persisted).
+     *
+     * @param array<string, mixed> $mergedData
+     *
+     * @return void
+     */
+    public function setMergedData(array $mergedData): void
+    {
+        $this->_mergedData = $mergedData;
+    }
+
+    /**
+     * Check if merged data has been set.
+     *
+     * @return bool
+     */
+    public function hasMergedData(): bool
+    {
+        return $this->_mergedData !== null;
+    }
+
+    /**
+     * Get merged data if set, otherwise return regular data.
+     *
+     * @return array<string, mixed>
+     */
+    public function getMergedData(): array
+    {
+        return $this->_mergedData ?? $this->getData();
     }
 
     /**

--- a/src/View/Helper/BouncerHelper.php
+++ b/src/View/Helper/BouncerHelper.php
@@ -43,7 +43,8 @@ class BouncerHelper extends Helper
             return [];
         }
 
-        $proposedData = $bouncerRecord->getData();
+        // Use merged data if available (for stale records with auto-merge)
+        $proposedData = $bouncerRecord->getMergedData();
         $currentData = $currentRecord->toArray();
         $allFields = array_unique(array_merge(array_keys($currentData), array_keys($proposedData)));
         sort($allFields);

--- a/src/View/Helper/BouncerHelper.php
+++ b/src/View/Helper/BouncerHelper.php
@@ -215,7 +215,7 @@ class BouncerHelper extends Helper
         $output = '<details class="mt-3">';
         $output .= '<summary><strong>' . __('Raw JSON Data') . '</strong></summary>';
         $output .= '<pre class="bg-light p-3 mt-2"><code>';
-        $output .= h(json_encode($bouncerRecord->getData(), JSON_PRETTY_PRINT));
+        $output .= h(json_encode($bouncerRecord->getData(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         $output .= '</code></pre></details>';
 
         return $output;
@@ -362,14 +362,14 @@ JS;
         }
 
         if (is_array($value)) {
-            return json_encode($value, JSON_PRETTY_PRINT) ?: '';
+            return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
         }
 
         if (is_scalar($value)) {
             return (string)$value;
         }
 
-        return json_encode($value) ?: '';
+        return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
     }
 
     /**
@@ -392,7 +392,7 @@ JS;
         }
 
         if (is_array($value)) {
-            return '<pre class="mb-0"><code>' . h(json_encode($value, JSON_PRETTY_PRINT)) . '</code></pre>';
+            return '<pre class="mb-0"><code>' . h(json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)) . '</code></pre>';
         }
 
         if (is_string($value) && strlen($value) > 100) {

--- a/templates/Admin/Bouncer/resolve.php
+++ b/templates/Admin/Bouncer/resolve.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \Bouncer\Model\Entity\BouncerRecord $bouncerRecord
+ * @var \Cake\Datasource\EntityInterface $currentRecord
+ * @var array $conflict
+ */
+
+$formatValue = function ($value) {
+    if ($value === null) {
+        return 'null';
+    }
+    if (is_bool($value)) {
+        return $value ? 'true' : 'false';
+    }
+    if (is_array($value) || is_object($value)) {
+        return json_encode($value);
+    }
+
+    return (string)$value;
+};
+?>
+<div class="bouncer resolve content">
+    <h1><?= __('Resolve Conflicts') ?></h1>
+
+    <div class="alert alert-warning">
+        <strong><?= __('Conflict Detected!') ?></strong>
+        <?= __('This record was modified after the draft was created, and some of the same fields were changed. Please choose which value to keep for each conflicting field.') ?>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-header">
+            <strong><?= __('Record: {0} #{1}', h($bouncerRecord->source), $bouncerRecord->primary_key) ?></strong>
+        </div>
+    </div>
+
+    <?= $this->Form->create(null, ['id' => 'resolve-form']) ?>
+
+    <div class="card mb-3">
+        <div class="card-header">
+            <strong><?= __('3-Way Merge') ?></strong>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-bordered table-sm">
+                    <thead class="table-light">
+                        <tr>
+                            <th style="width: 15%"><?= __('Field') ?></th>
+                            <th style="width: 20%"><?= __('Original') ?><br><small class="text-muted"><?= __('When draft created') ?></small></th>
+                            <th style="width: 20%"><?= __('Current') ?><br><small class="text-muted"><?= __('Live version now') ?></small></th>
+                            <th style="width: 20%"><?= __('Proposed') ?><br><small class="text-muted"><?= __('Your changes') ?></small></th>
+                            <th style="width: 25%"><?= __('Merged Result') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php
+                        $allFields = array_unique(array_merge(
+                            array_keys($conflict['original']),
+                            array_keys($conflict['current']),
+                            array_keys($conflict['proposed']),
+                        ));
+                        sort($allFields);
+
+                        foreach ($allFields as $field) {
+                            if (in_array($field, ['created', 'modified', 'id', '_delete'], true)) {
+                                continue;
+                            }
+
+                            $originalValue = $conflict['original'][$field] ?? null;
+                            $currentValue = $conflict['current'][$field] ?? null;
+                            $proposedValue = $conflict['proposed'][$field] ?? null;
+                            $hasConflict = isset($conflict['conflicts'][$field]);
+
+                            // Determine default merged value
+                            $defaultMerged = $proposedValue ?? $currentValue ?? $originalValue;
+
+                            $rowClass = $hasConflict ? 'table-danger' : '';
+                            ?>
+                            <tr class="<?= $rowClass ?>">
+                                <td>
+                                    <strong><?= h($field) ?></strong>
+                                    <?php if ($hasConflict) { ?>
+                                        <br><span class="badge bg-danger"><?= __('CONFLICT') ?></span>
+                                    <?php } ?>
+                                </td>
+                                <td class="text-muted">
+                                    <code class="small"><?= h($formatValue($originalValue)) ?></code>
+                                </td>
+                                <td class="text-info">
+                                    <code class="small"><?= h($formatValue($currentValue)) ?></code>
+                                </td>
+                                <td class="text-success">
+                                    <code class="small"><?= h($formatValue($proposedValue)) ?></code>
+                                </td>
+                                <td>
+                                    <?php if ($hasConflict) { ?>
+                                        <?= $this->Form->control("merged.{$field}", [
+                                            'label' => false,
+                                            'value' => $proposedValue,
+                                            'class' => 'form-control form-control-sm',
+                                            'id' => 'merged-' . $field,
+                                        ]) ?>
+                                        <div class="btn-group btn-group-sm mt-1" role="group">
+                                            <button type="button" class="btn btn-outline-secondary use-value"
+                                                    data-field="<?= h($field) ?>"
+                                                    data-value="<?= h($currentValue) ?>">
+                                                <?= __('Use Current') ?>
+                                            </button>
+                                            <button type="button" class="btn btn-outline-secondary use-value"
+                                                    data-field="<?= h($field) ?>"
+                                                    data-value="<?= h($proposedValue) ?>">
+                                                <?= __('Use Proposed') ?>
+                                            </button>
+                                        </div>
+                                    <?php } else { ?>
+                                        <?= $this->Form->hidden("merged.{$field}", ['value' => $defaultMerged]) ?>
+                                        <code class="small"><?= h($formatValue($defaultMerged)) ?></code>
+                                    <?php } ?>
+                                </td>
+                            </tr>
+                        <?php } ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <div class="d-flex justify-content-between">
+                <?= $this->Html->link(__('Cancel'), ['action' => 'view', $bouncerRecord->id], ['class' => 'btn btn-secondary']) ?>
+                <?= $this->Form->button(__('Save Merged Changes'), ['class' => 'btn btn-primary']) ?>
+            </div>
+        </div>
+    </div>
+
+    <?= $this->Form->end() ?>
+</div>
+
+<?php
+// Add helper for formatting values
+$this->Html->scriptBlock("
+document.querySelectorAll('.use-value').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        var field = this.dataset.field;
+        var value = this.dataset.value;
+        var input = document.getElementById('merged-' + field);
+        if (input) {
+            input.value = value;
+        }
+    });
+});
+", ['block' => true]);
+?>
+

--- a/templates/Admin/Bouncer/resolve.php
+++ b/templates/Admin/Bouncer/resolve.php
@@ -6,18 +6,22 @@
  * @var array $conflict
  */
 
-$formatValue = function ($value) {
+$formatValue = function ($value, bool $preserveNewlines = true) {
     if ($value === null) {
-        return 'null';
+        return '<em class="text-muted">null</em>';
     }
     if (is_bool($value)) {
         return $value ? 'true' : 'false';
     }
     if (is_array($value) || is_object($value)) {
-        return json_encode($value);
+        return h(json_encode($value, JSON_PRETTY_PRINT));
+    }
+    $str = (string)$value;
+    if ($preserveNewlines && str_contains($str, "\n")) {
+        return nl2br(h($str));
     }
 
-    return (string)$value;
+    return h($str);
 };
 ?>
 <div class="bouncer resolve content">
@@ -84,21 +88,26 @@ $formatValue = function ($value) {
                                     <?php } ?>
                                 </td>
                                 <td class="text-muted">
-                                    <code class="small"><?= h($formatValue($originalValue)) ?></code>
+                                    <div class="small text-break"><?= $formatValue($originalValue) ?></div>
                                 </td>
                                 <td class="text-info">
-                                    <code class="small"><?= h($formatValue($currentValue)) ?></code>
+                                    <div class="small text-break"><?= $formatValue($currentValue) ?></div>
                                 </td>
                                 <td class="text-success">
-                                    <code class="small"><?= h($formatValue($proposedValue)) ?></code>
+                                    <div class="small text-break"><?= $formatValue($proposedValue) ?></div>
                                 </td>
                                 <td>
-                                    <?php if ($hasConflict) { ?>
+                                    <?php if ($hasConflict) {
+                                        $isMultiline = is_string($proposedValue) && str_contains($proposedValue, "\n");
+                                        $inputType = $isMultiline ? 'textarea' : 'text';
+                                    ?>
                                         <?= $this->Form->control("merged.{$field}", [
+                                            'type' => $inputType,
                                             'label' => false,
                                             'value' => $proposedValue,
                                             'class' => 'form-control form-control-sm',
                                             'id' => 'merged-' . $field,
+                                            'rows' => $isMultiline ? 4 : null,
                                         ]) ?>
                                         <div class="btn-group btn-group-sm mt-1" role="group">
                                             <button type="button" class="btn btn-outline-secondary use-value"
@@ -114,7 +123,7 @@ $formatValue = function ($value) {
                                         </div>
                                     <?php } else { ?>
                                         <?= $this->Form->hidden("merged.{$field}", ['value' => $defaultMerged]) ?>
-                                        <code class="small"><?= h($formatValue($defaultMerged)) ?></code>
+                                        <div class="small text-break"><?= $formatValue($defaultMerged) ?></div>
                                     <?php } ?>
                                 </td>
                             </tr>

--- a/templates/Admin/Bouncer/resolve.php
+++ b/templates/Admin/Bouncer/resolve.php
@@ -186,12 +186,9 @@ $hasConflicts = !empty($conflict['conflicts']);
 
     <?php
     // Add hidden fields for non-conflicting, non-auto-merged fields
-    $allFields = array_unique(array_merge(
-        array_keys($conflict['original']),
-        array_keys($conflict['current']),
-        array_keys($conflict['proposed']),
-    ));
-    foreach ($allFields as $field) {
+    // Only include fields that were in the original proposal to avoid noise
+    $proposedFields = array_keys($conflict['proposed']);
+    foreach ($proposedFields as $field) {
         if (in_array($field, ['created', 'modified', 'id', '_delete'], true)) {
             continue;
         }

--- a/templates/Admin/Bouncer/resolve.php
+++ b/templates/Admin/Bouncer/resolve.php
@@ -14,7 +14,7 @@ $formatValue = function ($value, bool $preserveNewlines = true) {
         return $value ? 'true' : 'false';
     }
     if (is_array($value) || is_object($value)) {
-        return h(json_encode($value, JSON_PRETTY_PRINT));
+        return '<pre class="mb-0 small">' . h(json_encode($value, JSON_PRETTY_PRINT)) . '</pre>';
     }
     $str = (string)$value;
     if ($preserveNewlines && str_contains($str, "\n")) {
@@ -23,14 +23,26 @@ $formatValue = function ($value, bool $preserveNewlines = true) {
 
     return h($str);
 };
+
+$hasAutoMerged = !empty($conflict['autoMerged']);
+$hasConflicts = !empty($conflict['conflicts']);
 ?>
 <div class="bouncer resolve content">
     <h1><?= __('Resolve Conflicts') ?></h1>
 
-    <div class="alert alert-warning">
-        <strong><?= __('Conflict Detected!') ?></strong>
-        <?= __('This record was modified after the draft was created, and some of the same fields were changed. Please choose which value to keep for each conflicting field.') ?>
-    </div>
+    <?php if ($hasConflicts) { ?>
+        <div class="alert alert-danger">
+            <strong><?= __('Manual Resolution Required') ?></strong>
+            <?= __('Some fields have conflicting changes that could not be auto-merged. Please review and choose the correct value for each conflicting field.') ?>
+        </div>
+    <?php } ?>
+
+    <?php if ($hasAutoMerged) { ?>
+        <div class="alert alert-success">
+            <strong><?= __('Auto-Merged Successfully') ?></strong>
+            <?= __('Some fields were automatically merged because the changes did not overlap.') ?>
+        </div>
+    <?php } ?>
 
     <div class="card mb-3">
         <div class="card-header">
@@ -40,99 +52,156 @@ $formatValue = function ($value, bool $preserveNewlines = true) {
 
     <?= $this->Form->create(null, ['id' => 'resolve-form']) ?>
 
-    <div class="card mb-3">
-        <div class="card-header">
-            <strong><?= __('3-Way Merge') ?></strong>
+    <?php if ($hasAutoMerged) { ?>
+        <div class="card mb-3">
+            <div class="card-header bg-success text-white">
+                <strong><?= __('Auto-Merged Fields') ?></strong>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-bordered table-sm">
+                        <thead class="table-light">
+                            <tr>
+                                <th style="width: 12%"><?= __('Field') ?></th>
+                                <th style="width: 18%"><?= __('Original') ?></th>
+                                <th style="width: 18%"><?= __('Current') ?></th>
+                                <th style="width: 18%"><?= __('Proposed') ?></th>
+                                <th style="width: 18%"><?= __('Merged Result') ?></th>
+                                <th style="width: 16%"><?= __('Changes') ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($conflict['autoMerged'] as $field => $data) { ?>
+                                <tr class="table-success">
+                                    <td>
+                                        <strong><?= h($field) ?></strong>
+                                        <br><span class="badge bg-success"><?= __('AUTO-MERGED') ?></span>
+                                    </td>
+                                    <td class="text-muted">
+                                        <div class="small text-break"><?= $formatValue($data['original']) ?></div>
+                                    </td>
+                                    <td class="text-info">
+                                        <div class="small text-break"><?= $formatValue($data['current']) ?></div>
+                                    </td>
+                                    <td class="text-primary">
+                                        <div class="small text-break"><?= $formatValue($data['proposed']) ?></div>
+                                    </td>
+                                    <td class="bg-light">
+                                        <?= $this->Form->hidden("merged.{$field}", ['value' => $data['result']]) ?>
+                                        <div class="small text-break"><strong><?= $formatValue($data['result']) ?></strong></div>
+                                    </td>
+                                    <td class="small">
+                                        <?php if ($data['currentChanges']) { ?>
+                                            <div class="text-info mb-1">
+                                                <strong><?= __('Current:') ?></strong>
+                                                <?php foreach ($data['currentChanges'] as $change) { ?>
+                                                    <div><?= h($change) ?></div>
+                                                <?php } ?>
+                                            </div>
+                                        <?php } ?>
+                                        <?php if ($data['proposedChanges']) { ?>
+                                            <div class="text-primary">
+                                                <strong><?= __('Proposed:') ?></strong>
+                                                <?php foreach ($data['proposedChanges'] as $change) { ?>
+                                                    <div><?= h($change) ?></div>
+                                                <?php } ?>
+                                            </div>
+                                        <?php } ?>
+                                    </td>
+                                </tr>
+                            <?php } ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
-        <div class="card-body">
-            <div class="table-responsive">
-                <table class="table table-bordered table-sm">
-                    <thead class="table-light">
-                        <tr>
-                            <th style="width: 15%"><?= __('Field') ?></th>
-                            <th style="width: 20%"><?= __('Original') ?><br><small class="text-muted"><?= __('When draft created') ?></small></th>
-                            <th style="width: 20%"><?= __('Current') ?><br><small class="text-muted"><?= __('Live version now') ?></small></th>
-                            <th style="width: 20%"><?= __('Proposed') ?><br><small class="text-muted"><?= __('Your changes') ?></small></th>
-                            <th style="width: 25%"><?= __('Merged Result') ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php
-                        $allFields = array_unique(array_merge(
-                            array_keys($conflict['original']),
-                            array_keys($conflict['current']),
-                            array_keys($conflict['proposed']),
-                        ));
-                        sort($allFields);
+    <?php } ?>
 
-                        foreach ($allFields as $field) {
-                            if (in_array($field, ['created', 'modified', 'id', '_delete'], true)) {
-                                continue;
-                            }
-
-                            $originalValue = $conflict['original'][$field] ?? null;
-                            $currentValue = $conflict['current'][$field] ?? null;
-                            $proposedValue = $conflict['proposed'][$field] ?? null;
-                            $hasConflict = isset($conflict['conflicts'][$field]);
-
-                            // Determine default merged value
-                            $defaultMerged = $proposedValue ?? $currentValue ?? $originalValue;
-
-                            $rowClass = $hasConflict ? 'table-danger' : '';
+    <?php if ($hasConflicts) { ?>
+        <div class="card mb-3">
+            <div class="card-header bg-danger text-white">
+                <strong><?= __('Conflicting Fields - Manual Resolution Required') ?></strong>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-bordered table-sm">
+                        <thead class="table-light">
+                            <tr>
+                                <th style="width: 15%"><?= __('Field') ?></th>
+                                <th style="width: 20%"><?= __('Original') ?></th>
+                                <th style="width: 20%"><?= __('Current') ?></th>
+                                <th style="width: 20%"><?= __('Proposed') ?></th>
+                                <th style="width: 25%"><?= __('Choose Value') ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($conflict['conflicts'] as $field => $data) {
+                                $isMultiline = is_string($data['proposed']) && str_contains($data['proposed'], "\n");
+                                $inputType = $isMultiline ? 'textarea' : 'text';
                             ?>
-                            <tr class="<?= $rowClass ?>">
-                                <td>
-                                    <strong><?= h($field) ?></strong>
-                                    <?php if ($hasConflict) { ?>
+                                <tr class="table-danger">
+                                    <td>
+                                        <strong><?= h($field) ?></strong>
                                         <br><span class="badge bg-danger"><?= __('CONFLICT') ?></span>
-                                    <?php } ?>
-                                </td>
-                                <td class="text-muted">
-                                    <div class="small text-break"><?= $formatValue($originalValue) ?></div>
-                                </td>
-                                <td class="text-info">
-                                    <div class="small text-break"><?= $formatValue($currentValue) ?></div>
-                                </td>
-                                <td class="text-success">
-                                    <div class="small text-break"><?= $formatValue($proposedValue) ?></div>
-                                </td>
-                                <td>
-                                    <?php if ($hasConflict) {
-                                        $isMultiline = is_string($proposedValue) && str_contains($proposedValue, "\n");
-                                        $inputType = $isMultiline ? 'textarea' : 'text';
-                                    ?>
+                                    </td>
+                                    <td class="text-muted">
+                                        <div class="small text-break"><?= $formatValue($data['original']) ?></div>
+                                    </td>
+                                    <td class="text-info">
+                                        <div class="small text-break"><?= $formatValue($data['current']) ?></div>
+                                    </td>
+                                    <td class="text-primary">
+                                        <div class="small text-break"><?= $formatValue($data['proposed']) ?></div>
+                                    </td>
+                                    <td>
                                         <?= $this->Form->control("merged.{$field}", [
                                             'type' => $inputType,
                                             'label' => false,
-                                            'value' => $proposedValue,
+                                            'value' => $data['proposed'],
                                             'class' => 'form-control form-control-sm',
                                             'id' => 'merged-' . $field,
                                             'rows' => $isMultiline ? 4 : null,
                                         ]) ?>
                                         <div class="btn-group btn-group-sm mt-1" role="group">
-                                            <button type="button" class="btn btn-outline-secondary use-value"
+                                            <button type="button" class="btn btn-outline-info use-value"
                                                     data-field="<?= h($field) ?>"
-                                                    data-value="<?= h($currentValue) ?>">
+                                                    data-value="<?= h($data['current']) ?>">
                                                 <?= __('Use Current') ?>
                                             </button>
-                                            <button type="button" class="btn btn-outline-secondary use-value"
+                                            <button type="button" class="btn btn-outline-primary use-value"
                                                     data-field="<?= h($field) ?>"
-                                                    data-value="<?= h($proposedValue) ?>">
+                                                    data-value="<?= h($data['proposed']) ?>">
                                                 <?= __('Use Proposed') ?>
                                             </button>
                                         </div>
-                                    <?php } else { ?>
-                                        <?= $this->Form->hidden("merged.{$field}", ['value' => $defaultMerged]) ?>
-                                        <div class="small text-break"><?= $formatValue($defaultMerged) ?></div>
-                                    <?php } ?>
-                                </td>
-                            </tr>
-                        <?php } ?>
-                    </tbody>
-                </table>
+                                    </td>
+                                </tr>
+                            <?php } ?>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
-    </div>
+    <?php } ?>
+
+    <?php
+    // Add hidden fields for non-conflicting, non-auto-merged fields
+    $allFields = array_unique(array_merge(
+        array_keys($conflict['original']),
+        array_keys($conflict['current']),
+        array_keys($conflict['proposed']),
+    ));
+    foreach ($allFields as $field) {
+        if (in_array($field, ['created', 'modified', 'id', '_delete'], true)) {
+            continue;
+        }
+        if (isset($conflict['conflicts'][$field]) || isset($conflict['autoMerged'][$field])) {
+            continue;
+        }
+        $value = $conflict['merged'][$field] ?? $conflict['proposed'][$field] ?? null;
+        echo $this->Form->hidden("merged.{$field}", ['value' => $value]);
+    }
+    ?>
 
     <div class="card">
         <div class="card-body">
@@ -147,7 +216,6 @@ $formatValue = function ($value, bool $preserveNewlines = true) {
 </div>
 
 <?php
-// Add helper for formatting values
 $this->Html->scriptBlock("
 document.querySelectorAll('.use-value').forEach(function(btn) {
     btn.addEventListener('click', function() {
@@ -161,4 +229,3 @@ document.querySelectorAll('.use-value').forEach(function(btn) {
 });
 ", ['block' => true]);
 ?>
-

--- a/templates/Admin/Bouncer/view.php
+++ b/templates/Admin/Bouncer/view.php
@@ -3,10 +3,30 @@
  * @var \App\View\AppView $this
  * @var \Bouncer\Model\Entity\BouncerRecord $bouncerRecord
  * @var \Cake\Datasource\EntityInterface|null $currentRecord
+ * @var array|null $conflict
  */
 ?>
 <div class="bouncer view content">
     <h1><?= __('Review Proposed Changes') ?></h1>
+
+    <?php if (!empty($conflict) && $conflict['hasConflicts']) { ?>
+        <div class="alert alert-warning">
+            <strong><?= __('Conflict Detected!') ?></strong>
+            <?= __('This record was modified after the draft was created, and some of the same fields were changed. Please review and merge the changes before approval.') ?>
+            <div class="mt-2">
+                <?= $this->Html->link(
+                    __('Resolve Conflicts'),
+                    ['action' => 'resolve', $bouncerRecord->id],
+                    ['class' => 'btn btn-warning btn-sm']
+                ) ?>
+            </div>
+        </div>
+    <?php } elseif (!empty($conflict)) { ?>
+        <div class="alert alert-info">
+            <strong><?= __('Note:') ?></strong>
+            <?= __('This record was modified after the draft was created, but the changes affect different fields. You can proceed with approval.') ?>
+        </div>
+    <?php } ?>
 
     <div class="card mb-3">
         <div class="card-header">

--- a/templates/Admin/Bouncer/view.php
+++ b/templates/Admin/Bouncer/view.php
@@ -28,6 +28,13 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
         <div class="alert alert-info">
             <strong><?= __('Note:') ?></strong>
             <?= __('This record was modified after the draft was created, but the changes affect different fields. You can proceed with approval.') ?>
+            <div class="mt-2">
+                <?= $this->Html->link(
+                    __('View 3-Way Comparison'),
+                    ['action' => 'resolve', $bouncerRecord->id],
+                    ['class' => 'btn btn-info btn-sm']
+                ) ?>
+            </div>
         </div>
     <?php } ?>
 

--- a/tests/Fixture/BouncerRecordsFixture.php
+++ b/tests/Fixture/BouncerRecordsFixture.php
@@ -26,6 +26,7 @@ class BouncerRecordsFixture extends TestFixture
         'data' => ['type' => 'text', 'length' => 16777215, 'null' => false, 'default' => null],
         'original_data' => ['type' => 'text', 'length' => 16777215, 'null' => true, 'default' => null],
         'note' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null],
+        'original_modified' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null],
         'reason' => ['type' => 'text', 'null' => true, 'default' => null],
         'reviewed' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null],
         'created' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null],

--- a/tests/TestCase/Controller/Admin/BouncerControllerTest.php
+++ b/tests/TestCase/Controller/Admin/BouncerControllerTest.php
@@ -1,0 +1,637 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Test\TestCase\Controller\Admin;
+
+use Cake\I18n\DateTime;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Bouncer\Controller\Admin\BouncerController Test Case
+ */
+class BouncerControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+    use LocatorAwareTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var list<string>
+     */
+    protected array $fixtures = [
+        'plugin.Bouncer.BouncerRecords',
+        'plugin.Bouncer.Articles',
+    ];
+
+    /**
+     * @var \Bouncer\Model\Table\BouncerRecordsTable
+     */
+    protected $BouncerRecords;
+
+    /**
+     * @var \TestApp\Model\Table\ArticlesTable
+     */
+    protected $Articles;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->BouncerRecords = $this->fetchTable('Bouncer.BouncerRecords');
+        $this->Articles = $this->fetchTable('TestApp.Articles');
+
+        $this->enableRetainFlashMessages();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        unset($this->BouncerRecords, $this->Articles);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test index method
+     *
+     * @return void
+     */
+    public function testIndex(): void
+    {
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test index with status filter
+     *
+     * @return void
+     */
+    public function testIndexWithStatusFilter(): void
+    {
+        // Create a pending bouncer record
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]);
+
+        $this->assertResponseOk();
+        $this->assertResponseContains('Articles');
+    }
+
+    /**
+     * Test view method for new record proposal
+     *
+     * @return void
+     */
+    public function testViewNewRecordProposal(): void
+    {
+        // Create a pending new record bouncer record
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'New Article', 'body' => 'Content']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'view', $bouncerRecord->id]);
+
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test view method for edit proposal without conflict
+     *
+     * @return void
+     */
+    public function testViewEditProposalNoConflict(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+
+        // Create a pending edit bouncer record with same original_modified as article
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Updated Title', 'body' => 'Original Body']),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body']),
+            'original_modified' => $article->modified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'view', $bouncerRecord->id]);
+
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test view method detects stale draft (conflict)
+     *
+     * @return void
+     */
+    public function testViewEditProposalWithConflict(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Update the article (simulate concurrent edit)
+        $article->title = 'Updated by someone else';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Create a pending edit bouncer record with old original_modified
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Draft Title', 'body' => 'Original Body']),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body']),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'view', $bouncerRecord->id]);
+
+        $this->assertResponseOk();
+        // The view should detect the conflict and set it in the view vars
+    }
+
+    /**
+     * Test view method when source record no longer exists
+     *
+     * @return void
+     */
+    public function testViewEditProposalRecordDeleted(): void
+    {
+        // Create a pending edit bouncer record for non-existent article
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => 99999,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Draft Title']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'view', $bouncerRecord->id]);
+
+        $this->assertResponseOk();
+        $this->assertFlashMessage('The original record no longer exists.');
+    }
+
+    /**
+     * Test resolve method redirects for already processed record
+     *
+     * @return void
+     */
+    public function testResolveAlreadyProcessed(): void
+    {
+        // Create an approved bouncer record
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => 1,
+            'user_id' => 1,
+            'status' => 'approved',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('This record has already been processed.');
+    }
+
+    /**
+     * Test resolve method redirects for new record proposals
+     *
+     * @return void
+     */
+    public function testResolveNewRecordProposal(): void
+    {
+        // Create a pending new record proposal
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'New Article']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'view', $bouncerRecord->id]);
+        $this->assertFlashMessage('Conflict resolution is only available for edit proposals.');
+    }
+
+    /**
+     * Test resolve method redirects when source record no longer exists
+     *
+     * @return void
+     */
+    public function testResolveRecordDeleted(): void
+    {
+        // Create a pending edit bouncer record for non-existent article
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => 99999,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Draft Title']),
+            'original_modified' => new DateTime('-1 hour'),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('The original record no longer exists.');
+    }
+
+    /**
+     * Test resolve method redirects when no conflict detected
+     *
+     * @return void
+     */
+    public function testResolveNoConflict(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+
+        // Create a pending edit bouncer record with same original_modified
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Updated Title']),
+            'original_data' => json_encode(['title' => 'Original Title']),
+            'original_modified' => $article->modified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'view', $bouncerRecord->id]);
+        $this->assertFlashMessage('No conflict detected. You can proceed with normal approval.');
+    }
+
+    /**
+     * Test resolve method shows conflict interface
+     *
+     * @return void
+     */
+    public function testResolveShowsConflictInterface(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Update the article (simulate concurrent edit)
+        $article->title = 'Current Title';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Create a pending edit bouncer record with old original_modified
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'body' => 'Original Body']),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body']),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id]);
+
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test resolve method POST saves merged data
+     *
+     * @return void
+     */
+    public function testResolvePostSavesMergedData(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Update the article (simulate concurrent edit)
+        $article->title = 'Current Title';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Create a pending edit bouncer record with old original_modified
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'body' => 'Original Body']),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body']),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(
+            ['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id],
+            [
+                'merged' => [
+                    'title' => 'Merged Title',
+                    'body' => 'Original Body',
+                ],
+            ],
+        );
+
+        $this->assertRedirect(['action' => 'view', $bouncerRecord->id]);
+        $this->assertFlashMessage('Conflict resolved. Ready for final approval.');
+
+        // Verify the bouncer record was updated with merged data
+        $updatedRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $data = $updatedRecord->getData();
+        $this->assertEquals('Merged Title', $data['title']);
+    }
+
+    /**
+     * Test approve method requires POST
+     *
+     * @return void
+     */
+    public function testApproveRequiresPost(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Test', 'body' => 'Body', 'user_id' => 1]),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertResponseCode(405);
+    }
+
+    /**
+     * Test approve method for already processed record
+     *
+     * @return void
+     */
+    public function testApproveAlreadyProcessed(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => 1,
+            'user_id' => 1,
+            'status' => 'approved',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('This record has already been processed.');
+    }
+
+    /**
+     * Test approve method creates new record
+     *
+     * @return void
+     */
+    public function testApproveCreatesNewRecord(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'New Article', 'body' => 'Content', 'user_id' => 1]),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Changes have been approved and published.');
+
+        // Verify article was created
+        $article = $this->Articles->find()->where(['title' => 'New Article'])->first();
+        $this->assertNotNull($article);
+
+        // Verify bouncer record was updated
+        $updatedRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $this->assertEquals('approved', $updatedRecord->status);
+        $this->assertNotNull($updatedRecord->primary_key);
+    }
+
+    /**
+     * Test approve method applies edit
+     *
+     * @return void
+     */
+    public function testApproveAppliesEdit(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Updated Title', 'body' => 'Updated Body', 'user_id' => 1]),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Changes have been approved and published.');
+
+        // Verify article was updated
+        $updatedArticle = $this->Articles->get($article->id);
+        $this->assertEquals('Updated Title', $updatedArticle->title);
+        $this->assertEquals('Updated Body', $updatedArticle->body);
+    }
+
+    /**
+     * Test reject method requires POST
+     *
+     * @return void
+     */
+    public function testRejectRequiresPost(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'reject', $bouncerRecord->id]);
+
+        $this->assertResponseCode(405);
+    }
+
+    /**
+     * Test reject method for already processed record
+     *
+     * @return void
+     */
+    public function testRejectAlreadyProcessed(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => 1,
+            'user_id' => 1,
+            'status' => 'rejected',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'reject', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('This record has already been processed.');
+    }
+
+    /**
+     * Test reject method works
+     *
+     * @return void
+     */
+    public function testRejectWorks(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(
+            ['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'reject', $bouncerRecord->id],
+            ['reason' => 'Not acceptable'],
+        );
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Changes have been rejected.');
+
+        $updatedRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $this->assertEquals('rejected', $updatedRecord->status);
+        $this->assertEquals('Not acceptable', $updatedRecord->reason);
+    }
+
+    /**
+     * Test delete method requires POST
+     *
+     * @return void
+     */
+    public function testDeleteRequiresPost(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'delete', $bouncerRecord->id]);
+
+        $this->assertResponseCode(405);
+    }
+
+    /**
+     * Test delete method works
+     *
+     * @return void
+     */
+    public function testDeleteWorks(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+        $id = $bouncerRecord->id;
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'delete', $id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Bouncer record has been deleted.');
+
+        $this->assertFalse($this->BouncerRecords->exists(['id' => $id]));
+    }
+}

--- a/tests/TestCase/Controller/Admin/BouncerControllerTest.php
+++ b/tests/TestCase/Controller/Admin/BouncerControllerTest.php
@@ -634,4 +634,441 @@ class BouncerControllerTest extends TestCase
 
         $this->assertFalse($this->BouncerRecords->exists(['id' => $id]));
     }
+
+    /**
+     * Test approve auto-merges stale record with non-overlapping changes
+     *
+     * @return void
+     */
+    public function testApproveAutoMergesStaleRecordNonOverlapping(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Simulate concurrent edit - change body only
+        $article->body = 'Current Body Changed';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Create bouncer record that changes title only (non-overlapping)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Changes have been approved and published.');
+
+        // Verify article has BOTH changes - proposed title AND current body
+        $updatedArticle = $this->Articles->get($article->id);
+        $this->assertEquals('Proposed Title', $updatedArticle->title);
+        $this->assertEquals('Current Body Changed', $updatedArticle->body);
+    }
+
+    /**
+     * Test approve auto-merges stale record with string-level non-overlapping changes
+     *
+     * @return void
+     */
+    public function testApproveAutoMergesStaleRecordStringLevel(): void
+    {
+        // Create an article with text that will be modified in different places
+        $article = $this->Articles->newEntity([
+            'title' => 'Hello World Test',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Concurrent edit - change start of title
+        $article->title = 'Hi World Test';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Bouncer record changes end of title (non-overlapping within same field)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Hello World Test!', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Hello World Test', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Changes have been approved and published.');
+
+        // Verify article has merged title: "Hi World Test!"
+        $updatedArticle = $this->Articles->get($article->id);
+        $this->assertEquals('Hi World Test!', $updatedArticle->title);
+    }
+
+    /**
+     * Test approve redirects to resolve when there are conflicts
+     *
+     * @return void
+     */
+    public function testApproveRedirectsToResolveOnConflict(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Concurrent edit - change title
+        $article->title = 'Current Title';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Bouncer record also changes title (overlapping - conflict!)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'resolve', $bouncerRecord->id]);
+        $this->assertFlashMessage('This record has unresolved conflicts. Please resolve them first.');
+
+        // Verify article was NOT changed
+        $unchangedArticle = $this->Articles->get($article->id);
+        $this->assertEquals('Current Title', $unchangedArticle->title);
+
+        // Verify bouncer record is still pending
+        $unchangedRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $this->assertEquals('pending', $unchangedRecord->status);
+    }
+
+    /**
+     * Test approve works normally for non-stale records
+     *
+     * @return void
+     */
+    public function testApproveNonStaleRecordWorksNormally(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+
+        // Create bouncer record with same original_modified (not stale)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_modified' => $article->modified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Changes have been approved and published.');
+
+        $updatedArticle = $this->Articles->get($article->id);
+        $this->assertEquals('Proposed Title', $updatedArticle->title);
+    }
+
+    /**
+     * Test approve works for records without original_modified (legacy)
+     *
+     * @return void
+     */
+    public function testApproveLegacyRecordWithoutOriginalModified(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+
+        // Create bouncer record WITHOUT original_modified (legacy record)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_modified' => null,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+        $this->assertFlashMessage('Changes have been approved and published.');
+
+        $updatedArticle = $this->Articles->get($article->id);
+        $this->assertEquals('Proposed Title', $updatedArticle->title);
+    }
+
+    /**
+     * Test approve preserves fields not in proposal when auto-merging
+     *
+     * @return void
+     */
+    public function testApprovePreservesUnproposedFieldsOnMerge(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Concurrent edit - change body
+        $article->body = 'Current Body Changed';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Bouncer record only proposes title change (body not in proposal)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Original Title', 'user_id' => 1]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+
+        // Body should remain as current (not reverted to original)
+        $updatedArticle = $this->Articles->get($article->id);
+        $this->assertEquals('Proposed Title', $updatedArticle->title);
+        $this->assertEquals('Current Body Changed', $updatedArticle->body);
+    }
+
+    /**
+     * Test resolve shows auto-merged fields separately from conflicts
+     *
+     * @return void
+     */
+    public function testResolveShowsAutoMergedAndConflictsSeparately(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Concurrent edit - change both title and body
+        $article->title = 'Current Title';
+        $article->body = 'Current Body';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Bouncer record changes title (conflict) but not body
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Original Title', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id]);
+
+        $this->assertResponseOk();
+        $this->assertResponseContains('CONFLICT');
+        $this->assertResponseContains('title');
+    }
+
+    /**
+     * Test view page shows merged diff for stale records
+     *
+     * @return void
+     */
+    public function testViewShowsMergedDiffForStaleRecords(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Hello World',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Concurrent edit - change start
+        $article->title = 'Hi World';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Bouncer record changes end (non-overlapping)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Hello World!', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Hello World', 'body' => 'Original Body', 'user_id' => 1]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'view', $bouncerRecord->id]);
+
+        $this->assertResponseOk();
+        // Should show the merged result "Hi World!" in the diff
+        $this->assertResponseContains('Hi World!');
+    }
+
+    /**
+     * Test resolve post only includes proposed fields in merged data
+     *
+     * @return void
+     */
+    public function testResolvePostOnlyIncludesProposedFields(): void
+    {
+        // Create an article
+        $article = $this->Articles->newEntity([
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Concurrent edit
+        $article->title = 'Current Title';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Bouncer record with conflict
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['title' => 'Proposed Title', 'user_id' => 1]),
+            'original_data' => json_encode(['title' => 'Original Title', 'user_id' => 1]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        // Post merged data - only title should be saved, not body
+        $this->post(
+            ['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id],
+            [
+                'merged' => [
+                    'title' => 'Resolved Title',
+                    'user_id' => 1,
+                ],
+            ],
+        );
+
+        $this->assertRedirect(['action' => 'view', $bouncerRecord->id]);
+
+        // Verify only proposed fields are in data
+        $updatedRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $data = $updatedRecord->getData();
+        $this->assertEquals('Resolved Title', $data['title']);
+        $this->assertArrayNotHasKey('body', $data);
+    }
+
+    /**
+     * Test complex 3-way merge scenario with multiple fields
+     *
+     * @return void
+     */
+    public function testApproveComplexMergeScenario(): void
+    {
+        // Create an article with multiple fields
+        $article = $this->Articles->newEntity([
+            'title' => 'AAAA BBBB CCCC',
+            'body' => 'Line 1 here',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($article);
+        $originalModified = $article->modified;
+
+        // Concurrent edit - change middle of title, end of body
+        $article->title = 'AAAA XXXX CCCC';
+        $article->body = 'Line 1 here - updated';
+        $article->modified = new DateTime('+1 hour');
+        $this->Articles->save($article);
+
+        // Bouncer proposes changes to end of title, start of body (non-overlapping)
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $article->id,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode([
+                'title' => 'AAAA BBBB CCCC DDDD',
+                'body' => 'New Line 1 here',
+                'user_id' => 1,
+            ]),
+            'original_data' => json_encode([
+                'title' => 'AAAA BBBB CCCC',
+                'body' => 'Line 1 here',
+                'user_id' => 1,
+            ]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'approve', $bouncerRecord->id]);
+
+        $this->assertRedirect(['action' => 'index']);
+
+        // Verify merged result
+        $updatedArticle = $this->Articles->get($article->id);
+        // Title: current changed middle (XXXX), proposed added end (DDDD)
+        $this->assertEquals('AAAA XXXX CCCC DDDD', $updatedArticle->title);
+        // Body: proposed changed start (New), current changed end (- updated)
+        $this->assertEquals('New Line 1 here - updated', $updatedArticle->body);
+    }
 }

--- a/tests/TestCase/Controller/Admin/BouncerControllerTest.php
+++ b/tests/TestCase/Controller/Admin/BouncerControllerTest.php
@@ -315,7 +315,7 @@ class BouncerControllerTest extends TestCase
         $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'resolve', $bouncerRecord->id]);
 
         $this->assertRedirect(['action' => 'view', $bouncerRecord->id]);
-        $this->assertFlashMessage('No conflict detected. You can proceed with normal approval.');
+        $this->assertFlashMessage('No changes detected since draft creation. You can proceed with normal approval.');
     }
 
     /**

--- a/tests/TestCase/Lib/ThreeWayMergeTest.php
+++ b/tests/TestCase/Lib/ThreeWayMergeTest.php
@@ -281,4 +281,186 @@ class ThreeWayMergeTest extends TestCase
         $this->assertNotEmpty($result['currentChanges']);
         $this->assertStringContainsString('Removed', $result['currentChanges'][0]);
     }
+
+    /**
+     * Test mergeArrays with non-overlapping changes
+     *
+     * @return void
+     */
+    public function testMergeArraysNonOverlapping(): void
+    {
+        $original = [
+            'title' => 'Original Title',
+            'body' => 'Hello!!!! World',
+        ];
+        $current = [
+            'title' => 'Original Title',
+            'body' => 'Hello World', // Owner removed !!!!
+        ];
+        $proposed = [
+            'title' => 'Original Title',
+            'body' => 'Hello!!!! Universe', // Contributor changed World to Universe
+        ];
+
+        $result = $this->merger->mergeArrays($original, $current, $proposed);
+
+        $this->assertFalse($result['hasConflicts']);
+        $this->assertSame('Hello Universe', $result['merged']['body']);
+        $this->assertArrayHasKey('body', $result['autoMerged']);
+        $this->assertSame('text_merge', $result['autoMerged']['body']['reason']);
+    }
+
+    /**
+     * Test mergeArrays when only current changed
+     *
+     * @return void
+     */
+    public function testMergeArraysOnlyCurrentChanged(): void
+    {
+        $original = [
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+        ];
+        $current = [
+            'title' => 'Updated Title', // Owner changed title
+            'body' => 'Original Body',
+        ];
+        $proposed = [
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+        ];
+
+        $result = $this->merger->mergeArrays($original, $current, $proposed);
+
+        $this->assertFalse($result['hasConflicts']);
+        // Current's title change should be preserved
+        $this->assertSame('Updated Title', $result['merged']['title']);
+        $this->assertArrayHasKey('title', $result['autoMerged']);
+        $this->assertSame('current_only', $result['autoMerged']['title']['reason']);
+    }
+
+    /**
+     * Test mergeArrays when only proposed changed
+     *
+     * @return void
+     */
+    public function testMergeArraysOnlyProposedChanged(): void
+    {
+        $original = [
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+        ];
+        $current = [
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+        ];
+        $proposed = [
+            'title' => 'Original Title',
+            'body' => 'Proposed Body', // Contributor changed body
+        ];
+
+        $result = $this->merger->mergeArrays($original, $current, $proposed);
+
+        $this->assertFalse($result['hasConflicts']);
+        // Proposed's body change should be in merged
+        $this->assertSame('Proposed Body', $result['merged']['body']);
+        // No auto-merged since only proposed changed
+        $this->assertEmpty($result['autoMerged']);
+    }
+
+    /**
+     * Test mergeArrays detects conflicts
+     *
+     * @return void
+     */
+    public function testMergeArraysDetectsConflicts(): void
+    {
+        $original = [
+            'title' => 'Original Title',
+            'body' => 'Original Body',
+        ];
+        $current = [
+            'title' => 'Current Title', // Owner changed
+            'body' => 'Original Body',
+        ];
+        $proposed = [
+            'title' => 'Proposed Title', // Contributor also changed (same field!)
+            'body' => 'Original Body',
+        ];
+
+        $result = $this->merger->mergeArrays($original, $current, $proposed);
+
+        $this->assertTrue($result['hasConflicts']);
+        $this->assertArrayHasKey('title', $result['conflicts']);
+        $this->assertSame('Original Title', $result['conflicts']['title']['original']);
+        $this->assertSame('Current Title', $result['conflicts']['title']['current']);
+        $this->assertSame('Proposed Title', $result['conflicts']['title']['proposed']);
+        // Merged defaults to proposed for conflicts
+        $this->assertSame('Proposed Title', $result['merged']['title']);
+    }
+
+    /**
+     * Test mergeArrays skips configured fields
+     *
+     * @return void
+     */
+    public function testMergeArraysSkipsFields(): void
+    {
+        $original = [
+            'id' => 1,
+            'created' => '2024-01-01',
+            'modified' => '2024-01-01',
+            'title' => 'Original Title',
+        ];
+        $current = [
+            'id' => 1,
+            'created' => '2024-01-01',
+            'modified' => '2024-06-01', // Modified changed
+            'title' => 'Current Title',
+        ];
+        $proposed = [
+            'id' => 1,
+            'created' => '2024-01-01',
+            'modified' => '2024-01-01',
+            'title' => 'Proposed Title',
+        ];
+
+        $result = $this->merger->mergeArrays($original, $current, $proposed);
+
+        // id, created, modified should be skipped - no conflict on those
+        $this->assertTrue($result['hasConflicts']);
+        $this->assertArrayNotHasKey('id', $result['conflicts']);
+        $this->assertArrayNotHasKey('created', $result['conflicts']);
+        $this->assertArrayNotHasKey('modified', $result['conflicts']);
+        // Only title should be in conflicts
+        $this->assertArrayHasKey('title', $result['conflicts']);
+    }
+
+    /**
+     * Test mergeArrays with custom skip fields
+     *
+     * @return void
+     */
+    public function testMergeArraysCustomSkipFields(): void
+    {
+        $original = [
+            'title' => 'Original',
+            'internal_field' => 'Original',
+        ];
+        $current = [
+            'title' => 'Current',
+            'internal_field' => 'Current',
+        ];
+        $proposed = [
+            'title' => 'Proposed',
+            'internal_field' => 'Proposed',
+        ];
+
+        $result = $this->merger->mergeArrays($original, $current, $proposed, ['internal_field']);
+
+        // internal_field should be skipped
+        $this->assertArrayNotHasKey('internal_field', $result['conflicts']);
+        // title should be in conflicts
+        $this->assertArrayHasKey('title', $result['conflicts']);
+    }
 }

--- a/tests/TestCase/Lib/ThreeWayMergeTest.php
+++ b/tests/TestCase/Lib/ThreeWayMergeTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Test\TestCase\Lib;
+
+use Bouncer\Lib\ThreeWayMerge;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ThreeWayMerge Test Case
+ */
+class ThreeWayMergeTest extends TestCase
+{
+    /**
+     * @var \Bouncer\Lib\ThreeWayMerge
+     */
+    protected ThreeWayMerge $merger;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->merger = new ThreeWayMerge();
+    }
+
+    /**
+     * Test when only current changed
+     *
+     * @return void
+     */
+    public function testMergeOnlyCurrentChanged(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'original text',
+            'modified text',
+            'original text',
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('modified text', $result['result']);
+    }
+
+    /**
+     * Test when only proposed changed
+     *
+     * @return void
+     */
+    public function testMergeOnlyProposedChanged(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'original text',
+            'original text',
+            'proposed text',
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('proposed text', $result['result']);
+    }
+
+    /**
+     * Test when both changed to same value
+     *
+     * @return void
+     */
+    public function testMergeBothChangedSame(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'original text',
+            'same change',
+            'same change',
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('same change', $result['result']);
+    }
+
+    /**
+     * Test non-overlapping changes - current changes start, proposed changes end
+     *
+     * @return void
+     */
+    public function testMergeNonOverlappingChangesStartEnd(): void
+    {
+        $result = $this->merger->mergeStrings(
+            '#### sdfsdfdfsdfsx!!!!1235411a',
+            '#### 111dfsx!!!!1235411a', // changed middle
+            '#### sdfsdfdfsdfsx!!!!1235411a!!!!!', // added at end
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('#### 111dfsx!!!!1235411a!!!!!', $result['result']);
+    }
+
+    /**
+     * Test non-overlapping changes - proposed changes start, current changes end
+     *
+     * @return void
+     */
+    public function testMergeNonOverlappingChangesEndStart(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'Hello World!',
+            'Hello World! Goodbye.', // added at end
+            'Hi World!', // changed start
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('Hi World! Goodbye.', $result['result']);
+    }
+
+    /**
+     * Test overlapping changes - true conflict
+     *
+     * @return void
+     */
+    public function testMergeOverlappingChangesConflict(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'Hello World',
+            'Hello Universe', // changed "World" to "Universe"
+            'Hello Planet', // changed "World" to "Planet"
+        );
+
+        $this->assertEquals(ThreeWayMerge::CONFLICT, $result['status']);
+    }
+
+    /**
+     * Test prefix addition on one side, suffix addition on other
+     *
+     * @return void
+     */
+    public function testMergePrefixAndSuffixAdditions(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'middle',
+            'prefix middle', // added prefix
+            'middle suffix', // added suffix
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('prefix middle suffix', $result['result']);
+    }
+
+    /**
+     * Test deletion on one side, addition on other side (non-overlapping)
+     *
+     * @return void
+     */
+    public function testMergeDeletionAndAddition(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'abc def ghi',
+            'abc ghi', // deleted "def "
+            'abc def ghi jkl', // added " jkl"
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('abc ghi jkl', $result['result']);
+    }
+
+    /**
+     * Test with empty original
+     *
+     * @return void
+     */
+    public function testMergeEmptyOriginal(): void
+    {
+        $result = $this->merger->mergeStrings(
+            '',
+            'current added',
+            'proposed added',
+        );
+
+        // Both added different content - conflict
+        $this->assertEquals(ThreeWayMerge::CONFLICT, $result['status']);
+    }
+
+    /**
+     * Test with one side becoming empty
+     *
+     * @return void
+     */
+    public function testMergeOneBecomesEmpty(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'some text',
+            '',
+            'some text',
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('', $result['result']);
+    }
+
+    /**
+     * Test multiline text merge
+     *
+     * @return void
+     */
+    public function testMergeMultilineText(): void
+    {
+        $original = "Line 1\nLine 2\nLine 3";
+        $current = "Line 1 modified\nLine 2\nLine 3"; // Changed first line
+        $proposed = "Line 1\nLine 2\nLine 3 modified"; // Changed last line
+
+        $result = $this->merger->mergeStrings($original, $current, $proposed);
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals("Line 1 modified\nLine 2\nLine 3 modified", $result['result']);
+    }
+
+    /**
+     * Test UTF-8 characters
+     *
+     * @return void
+     */
+    public function testMergeUtf8Characters(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'Hello 世界',
+            'Hi 世界', // Changed start
+            'Hello 世界!', // Added at end
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('Hi 世界!', $result['result']);
+    }
+
+    /**
+     * Test identical strings (no change)
+     *
+     * @return void
+     */
+    public function testMergeIdenticalStrings(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'unchanged',
+            'unchanged',
+            'unchanged',
+        );
+
+        $this->assertEquals(ThreeWayMerge::MERGED, $result['status']);
+        $this->assertEquals('unchanged', $result['result']);
+    }
+
+    /**
+     * Test describe changes shows additions
+     *
+     * @return void
+     */
+    public function testDescribeChangesAddition(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'text',
+            'text',
+            'text added',
+        );
+
+        $this->assertNotEmpty($result['proposedChanges']);
+        $this->assertStringContainsString('Added', $result['proposedChanges'][0]);
+    }
+
+    /**
+     * Test describe changes shows removals
+     *
+     * @return void
+     */
+    public function testDescribeChangesRemoval(): void
+    {
+        $result = $this->merger->mergeStrings(
+            'text to remove',
+            'text',
+            'text to remove',
+        );
+
+        $this->assertNotEmpty($result['currentChanges']);
+        $this->assertStringContainsString('Removed', $result['currentChanges'][0]);
+    }
+}

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
@@ -1499,4 +1499,223 @@ class BouncerBehaviorTest extends TestCase
         $this->assertEquals('Articles', $bouncerRecord->source);
         $this->assertNotEquals('TestApp.Articles', $bouncerRecord->source);
     }
+
+    /**
+     * Test that applyApprovedChanges auto-merges stale edit proposals.
+     *
+     * Scenario:
+     * 1. Owner has content "Hello!!!! World" (original)
+     * 2. Contributor proposes change: "Hello!!!! Universe" (proposed - changes "World" to "Universe")
+     * 3. Owner edits their article: "Hello World" (current - removes "!!!!")
+     * 4. When approved, result should be "Hello Universe" (merged - both changes preserved)
+     *
+     * @return void
+     */
+    public function testApplyApprovedChangesAutoMergesStaleProposal(): void
+    {
+        $this->Articles->addBehavior('Bouncer.Bouncer');
+
+        // Create original article
+        $originalBody = 'Hello!!!! World';
+        $article = $this->Articles->newEntity([
+            'title' => 'Test Article',
+            'body' => $originalBody,
+            'user_id' => 1,
+        ]);
+        $article = $this->Articles->save($article, ['bypassBouncer' => true]);
+        $this->assertNotFalse($article);
+        $articleId = $article->id;
+        // Store the original modified time (go back 1 second to ensure staleness detection)
+        $originalModified = $article->modified->subSeconds(1);
+
+        // Simulate a proposal that was created BEFORE owner edited
+        // Contributor changes "World" to "Universe" but keeps "!!!!"
+        $proposedBody = 'Hello!!!! Universe';
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $articleId,
+            'user_id' => 2, // Different user (contributor)
+            'status' => 'pending',
+            'data' => json_encode(['body' => $proposedBody]),
+            'original_data' => json_encode(['body' => $originalBody]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        // Owner edits their article - removes "!!!!"
+        $currentBody = 'Hello World';
+        $article = $this->Articles->get($articleId);
+        $article->body = $currentBody;
+        $this->Articles->save($article, ['bypassBouncer' => true]);
+
+        // Verify article was updated
+        $article = $this->Articles->get($articleId);
+        $this->assertSame($currentBody, $article->body);
+
+        // Now apply the stale proposal - it should auto-merge
+        $bouncerRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $result = $this->Articles->getBehavior('Bouncer')->applyApprovedChanges($bouncerRecord);
+
+        $this->assertNotFalse($result);
+
+        // The merged result should be "Hello Universe"
+        // - Owner's removal of "!!!!" is preserved
+        // - Contributor's "World" -> "Universe" change is applied
+        $article = $this->Articles->get($articleId);
+        $expectedBody = 'Hello Universe';
+        $this->assertSame(
+            $expectedBody,
+            $article->body,
+            sprintf(
+                '3-way merge failed. Expected "%s", got "%s". Original: "%s", Current: "%s", Proposed: "%s"',
+                $expectedBody,
+                $article->body,
+                $originalBody,
+                $currentBody,
+                $proposedBody,
+            ),
+        );
+    }
+
+    /**
+     * Test that applyApprovedChanges can be configured to skip auto-merge.
+     *
+     * @return void
+     */
+    public function testApplyApprovedChangesAutoMergeCanBeDisabled(): void
+    {
+        $this->Articles->addBehavior('Bouncer.Bouncer');
+
+        // Create original article
+        $originalBody = 'Hello!!!! World';
+        $article = $this->Articles->newEntity([
+            'title' => 'Test Article',
+            'body' => $originalBody,
+            'user_id' => 1,
+        ]);
+        $article = $this->Articles->save($article, ['bypassBouncer' => true]);
+        $articleId = $article->id;
+        $originalModified = $article->modified->subSeconds(1);
+
+        // Create stale proposal
+        $proposedBody = 'Hello!!!! Universe';
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $articleId,
+            'user_id' => 2,
+            'status' => 'pending',
+            'data' => json_encode(['body' => $proposedBody]),
+            'original_data' => json_encode(['body' => $originalBody]),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        // Owner edits their article
+        $currentBody = 'Hello World';
+        $article = $this->Articles->get($articleId);
+        $article->body = $currentBody;
+        $this->Articles->save($article, ['bypassBouncer' => true]);
+
+        // Apply with autoMerge disabled - should use proposed data as-is
+        $bouncerRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $result = $this->Articles->getBehavior('Bouncer')->applyApprovedChanges($bouncerRecord, ['autoMerge' => false]);
+
+        $this->assertNotFalse($result);
+
+        // Without auto-merge, the proposed value should be applied directly
+        $article = $this->Articles->get($articleId);
+        $this->assertSame($proposedBody, $article->body);
+    }
+
+    /**
+     * Test that pre-merged data takes precedence over auto-merge.
+     *
+     * @return void
+     */
+    public function testApplyApprovedChangesRespectsPreMergedData(): void
+    {
+        $this->Articles->addBehavior('Bouncer.Bouncer');
+
+        // Create original article
+        $article = $this->Articles->newEntity([
+            'title' => 'Test Article',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $article = $this->Articles->save($article, ['bypassBouncer' => true]);
+        $articleId = $article->id;
+        $originalModified = $article->modified->subSeconds(1);
+
+        // Create stale proposal
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $articleId,
+            'user_id' => 2,
+            'status' => 'pending',
+            'data' => json_encode(['body' => 'Proposed Body']),
+            'original_data' => json_encode(['body' => 'Original Body']),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        // Owner edits their article
+        $article = $this->Articles->get($articleId);
+        $article->body = 'Current Body';
+        $this->Articles->save($article, ['bypassBouncer' => true]);
+
+        // Pre-set merged data - this should take precedence
+        $bouncerRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $bouncerRecord->setMergedData(['body' => 'Custom Merged Body']);
+
+        $result = $this->Articles->getBehavior('Bouncer')->applyApprovedChanges($bouncerRecord);
+
+        $this->assertNotFalse($result);
+
+        // The pre-merged data should be used, not auto-merge
+        $article = $this->Articles->get($articleId);
+        $this->assertSame('Custom Merged Body', $article->body);
+    }
+
+    /**
+     * Test that non-stale proposals don't trigger auto-merge.
+     *
+     * @return void
+     */
+    public function testApplyApprovedChangesNoMergeForFreshProposal(): void
+    {
+        $this->Articles->addBehavior('Bouncer.Bouncer');
+
+        // Create original article
+        $article = $this->Articles->newEntity([
+            'title' => 'Test Article',
+            'body' => 'Original Body',
+            'user_id' => 1,
+        ]);
+        $article = $this->Articles->save($article, ['bypassBouncer' => true]);
+        $articleId = $article->id;
+        // Set original_modified to the future so it's not stale
+        $originalModified = $article->modified->addSeconds(10);
+
+        // Create "fresh" proposal (original_modified is in the future)
+        $proposedBody = 'Proposed Body';
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => $articleId,
+            'user_id' => 2,
+            'status' => 'pending',
+            'data' => json_encode(['body' => $proposedBody]),
+            'original_data' => json_encode(['body' => 'Original Body']),
+            'original_modified' => $originalModified,
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+
+        // Apply - since not stale, should just use proposed data
+        $bouncerRecord = $this->BouncerRecords->get($bouncerRecord->id);
+        $result = $this->Articles->getBehavior('Bouncer')->applyApprovedChanges($bouncerRecord);
+
+        $this->assertNotFalse($result);
+
+        $article = $this->Articles->get($articleId);
+        $this->assertSame($proposedBody, $article->body);
+    }
 }

--- a/tests/TestCase/Model/Entity/BouncerRecordTest.php
+++ b/tests/TestCase/Model/Entity/BouncerRecordTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Test\TestCase\Model\Entity;
+
+use Bouncer\Model\Entity\BouncerRecord;
+use Cake\I18n\DateTime;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Bouncer\Model\Entity\BouncerRecord Test Case
+ */
+class BouncerRecordTest extends TestCase
+{
+    /**
+     * Test getData method with valid JSON
+     *
+     * @return void
+     */
+    public function testGetDataWithValidJson(): void
+    {
+        $entity = new BouncerRecord([
+            'data' => json_encode(['title' => 'Test', 'body' => 'Content']),
+        ]);
+
+        $result = $entity->getData();
+
+        $this->assertIsArray($result);
+        $this->assertEquals('Test', $result['title']);
+        $this->assertEquals('Content', $result['body']);
+    }
+
+    /**
+     * Test getData method with empty data
+     *
+     * @return void
+     */
+    public function testGetDataWithEmptyData(): void
+    {
+        $entity = new BouncerRecord([
+            'data' => '',
+        ]);
+
+        $result = $entity->getData();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test getData method with null data
+     *
+     * @return void
+     */
+    public function testGetDataWithNullData(): void
+    {
+        $entity = new BouncerRecord([]);
+
+        $result = $entity->getData();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test getOriginalData method with valid JSON
+     *
+     * @return void
+     */
+    public function testGetOriginalDataWithValidJson(): void
+    {
+        $entity = new BouncerRecord([
+            'original_data' => json_encode(['title' => 'Original', 'body' => 'Original Content']),
+        ]);
+
+        $result = $entity->getOriginalData();
+
+        $this->assertIsArray($result);
+        $this->assertEquals('Original', $result['title']);
+        $this->assertEquals('Original Content', $result['body']);
+    }
+
+    /**
+     * Test getOriginalData method with empty data
+     *
+     * @return void
+     */
+    public function testGetOriginalDataWithEmptyData(): void
+    {
+        $entity = new BouncerRecord([
+            'original_data' => '',
+        ]);
+
+        $result = $entity->getOriginalData();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test getOriginalData method with null data
+     *
+     * @return void
+     */
+    public function testGetOriginalDataWithNullData(): void
+    {
+        $entity = new BouncerRecord([]);
+
+        $result = $entity->getOriginalData();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test isNewRecordProposal method
+     *
+     * @return void
+     */
+    public function testIsNewRecordProposal(): void
+    {
+        $newRecord = new BouncerRecord([
+            'primary_key' => null,
+        ]);
+
+        $editRecord = new BouncerRecord([
+            'primary_key' => 1,
+        ]);
+
+        $this->assertTrue($newRecord->isNewRecordProposal());
+        $this->assertFalse($editRecord->isNewRecordProposal());
+    }
+
+    /**
+     * Test isEditProposal method
+     *
+     * @return void
+     */
+    public function testIsEditProposal(): void
+    {
+        $newRecord = new BouncerRecord([
+            'primary_key' => null,
+        ]);
+
+        $editRecord = new BouncerRecord([
+            'primary_key' => 1,
+        ]);
+
+        $this->assertFalse($newRecord->isEditProposal());
+        $this->assertTrue($editRecord->isEditProposal());
+    }
+
+    /**
+     * Test isPending method
+     *
+     * @return void
+     */
+    public function testIsPending(): void
+    {
+        $pending = new BouncerRecord(['status' => 'pending']);
+        $approved = new BouncerRecord(['status' => 'approved']);
+        $rejected = new BouncerRecord(['status' => 'rejected']);
+
+        $this->assertTrue($pending->isPending());
+        $this->assertFalse($approved->isPending());
+        $this->assertFalse($rejected->isPending());
+    }
+
+    /**
+     * Test isApproved method
+     *
+     * @return void
+     */
+    public function testIsApproved(): void
+    {
+        $pending = new BouncerRecord(['status' => 'pending']);
+        $approved = new BouncerRecord(['status' => 'approved']);
+        $rejected = new BouncerRecord(['status' => 'rejected']);
+
+        $this->assertFalse($pending->isApproved());
+        $this->assertTrue($approved->isApproved());
+        $this->assertFalse($rejected->isApproved());
+    }
+
+    /**
+     * Test isRejected method
+     *
+     * @return void
+     */
+    public function testIsRejected(): void
+    {
+        $pending = new BouncerRecord(['status' => 'pending']);
+        $approved = new BouncerRecord(['status' => 'approved']);
+        $rejected = new BouncerRecord(['status' => 'rejected']);
+
+        $this->assertFalse($pending->isRejected());
+        $this->assertFalse($approved->isRejected());
+        $this->assertTrue($rejected->isRejected());
+    }
+
+    /**
+     * Test isDeleteProposal method
+     *
+     * @return void
+     */
+    public function testIsDeleteProposal(): void
+    {
+        $deleteProposal = new BouncerRecord([
+            'data' => json_encode(['_delete' => true]),
+        ]);
+
+        $editProposal = new BouncerRecord([
+            'data' => json_encode(['title' => 'Updated']),
+        ]);
+
+        $deleteProposalFalse = new BouncerRecord([
+            'data' => json_encode(['_delete' => false]),
+        ]);
+
+        $this->assertTrue($deleteProposal->isDeleteProposal());
+        $this->assertFalse($editProposal->isDeleteProposal());
+        $this->assertFalse($deleteProposalFalse->isDeleteProposal());
+    }
+
+    /**
+     * Test hasOriginalModified method
+     *
+     * @return void
+     */
+    public function testHasOriginalModified(): void
+    {
+        $withOriginalModified = new BouncerRecord([
+            'original_modified' => new DateTime(),
+        ]);
+
+        $withoutOriginalModified = new BouncerRecord([]);
+
+        $this->assertTrue($withOriginalModified->hasOriginalModified());
+        $this->assertFalse($withoutOriginalModified->hasOriginalModified());
+    }
+
+    /**
+     * Test canDetectStaleness method
+     *
+     * @return void
+     */
+    public function testCanDetectStaleness(): void
+    {
+        $withOriginalModified = new BouncerRecord([
+            'original_modified' => new DateTime(),
+        ]);
+
+        $withNullOriginalModified = new BouncerRecord([
+            'original_modified' => null,
+        ]);
+
+        $withoutField = new BouncerRecord([]);
+
+        $this->assertTrue($withOriginalModified->canDetectStaleness());
+        $this->assertFalse($withNullOriginalModified->canDetectStaleness());
+        $this->assertFalse($withoutField->canDetectStaleness());
+    }
+
+    /**
+     * Test entity accessible fields
+     *
+     * @return void
+     */
+    public function testAccessibleFields(): void
+    {
+        $entity = new BouncerRecord([
+            'source' => 'Articles',
+            'primary_key' => 1,
+            'user_id' => 1,
+            'reviewer_id' => 2,
+            'status' => 'pending',
+            'data' => '{}',
+            'original_data' => '{}',
+            'note' => 'Test note',
+            'original_modified' => new DateTime(),
+            'reason' => 'Test reason',
+            'reviewed' => new DateTime(),
+            'created' => new DateTime(),
+            'modified' => new DateTime(),
+        ]);
+
+        $this->assertEquals('Articles', $entity->source);
+        $this->assertEquals(1, $entity->primary_key);
+        $this->assertEquals(1, $entity->user_id);
+        $this->assertEquals(2, $entity->reviewer_id);
+        $this->assertEquals('pending', $entity->status);
+        $this->assertEquals('{}', $entity->data);
+        $this->assertEquals('{}', $entity->original_data);
+        $this->assertEquals('Test note', $entity->note);
+        $this->assertInstanceOf(DateTime::class, $entity->original_modified);
+        $this->assertEquals('Test reason', $entity->reason);
+        $this->assertInstanceOf(DateTime::class, $entity->reviewed);
+    }
+}

--- a/tests/TestCase/Model/Entity/BouncerRecordTest.php
+++ b/tests/TestCase/Model/Entity/BouncerRecordTest.php
@@ -297,4 +297,102 @@ class BouncerRecordTest extends TestCase
         $this->assertEquals('Test reason', $entity->reason);
         $this->assertInstanceOf(DateTime::class, $entity->reviewed);
     }
+
+    /**
+     * Test isStale method returns true when source was modified after draft
+     *
+     * @return void
+     */
+    public function testIsStaleReturnsTrue(): void
+    {
+        $entity = new BouncerRecord([
+            'original_modified' => new DateTime('-1 hour'),
+        ]);
+
+        $currentEntity = new \Cake\ORM\Entity([
+            'modified' => new DateTime('now'),
+        ]);
+
+        $this->assertTrue($entity->isStale($currentEntity));
+    }
+
+    /**
+     * Test isStale method returns false when source was not modified
+     *
+     * @return void
+     */
+    public function testIsStaleReturnsFalse(): void
+    {
+        $entity = new BouncerRecord([
+            'original_modified' => new DateTime('+1 hour'),
+        ]);
+
+        $currentEntity = new \Cake\ORM\Entity([
+            'modified' => new DateTime('now'),
+        ]);
+
+        $this->assertFalse($entity->isStale($currentEntity));
+    }
+
+    /**
+     * Test isStale method returns false when no original_modified
+     *
+     * @return void
+     */
+    public function testIsStaleReturnsFalseWithoutOriginalModified(): void
+    {
+        $entity = new BouncerRecord([]);
+
+        $currentEntity = new \Cake\ORM\Entity([
+            'modified' => new DateTime('now'),
+        ]);
+
+        $this->assertFalse($entity->isStale($currentEntity));
+    }
+
+    /**
+     * Test buildMergeResult returns null when not stale
+     *
+     * @return void
+     */
+    public function testBuildMergeResultReturnsNullWhenNotStale(): void
+    {
+        $entity = new BouncerRecord([
+            'original_modified' => new DateTime('+1 hour'),
+            'data' => json_encode(['content' => 'proposed']),
+            'original_data' => json_encode(['content' => 'original']),
+        ]);
+
+        $currentEntity = new \Cake\ORM\Entity([
+            'modified' => new DateTime('now'),
+            'content' => 'current',
+        ]);
+
+        $this->assertNull($entity->buildMergeResult($currentEntity));
+    }
+
+    /**
+     * Test buildMergeResult returns merge result when stale
+     *
+     * @return void
+     */
+    public function testBuildMergeResultReturnsMergeWhenStale(): void
+    {
+        $entity = new BouncerRecord([
+            'original_modified' => new DateTime('-1 hour'),
+            'data' => json_encode(['content' => 'Hello!!!! Universe']),
+            'original_data' => json_encode(['content' => 'Hello!!!! World']),
+        ]);
+
+        $currentEntity = new \Cake\ORM\Entity([
+            'modified' => new DateTime('now'),
+            'content' => 'Hello World',
+        ]);
+
+        $result = $entity->buildMergeResult($currentEntity);
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result['hasConflicts']);
+        $this->assertSame('Hello Universe', $result['merged']['content']);
+    }
 }

--- a/tests/TestCase/Model/Entity/BouncerRecordTest.php
+++ b/tests/TestCase/Model/Entity/BouncerRecordTest.php
@@ -6,6 +6,7 @@ namespace Bouncer\Test\TestCase\Model\Entity;
 
 use Bouncer\Model\Entity\BouncerRecord;
 use Cake\I18n\DateTime;
+use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -309,7 +310,7 @@ class BouncerRecordTest extends TestCase
             'original_modified' => new DateTime('-1 hour'),
         ]);
 
-        $currentEntity = new \Cake\ORM\Entity([
+        $currentEntity = new Entity([
             'modified' => new DateTime('now'),
         ]);
 
@@ -327,7 +328,7 @@ class BouncerRecordTest extends TestCase
             'original_modified' => new DateTime('+1 hour'),
         ]);
 
-        $currentEntity = new \Cake\ORM\Entity([
+        $currentEntity = new Entity([
             'modified' => new DateTime('now'),
         ]);
 
@@ -343,7 +344,7 @@ class BouncerRecordTest extends TestCase
     {
         $entity = new BouncerRecord([]);
 
-        $currentEntity = new \Cake\ORM\Entity([
+        $currentEntity = new Entity([
             'modified' => new DateTime('now'),
         ]);
 
@@ -363,7 +364,7 @@ class BouncerRecordTest extends TestCase
             'original_data' => json_encode(['content' => 'original']),
         ]);
 
-        $currentEntity = new \Cake\ORM\Entity([
+        $currentEntity = new Entity([
             'modified' => new DateTime('now'),
             'content' => 'current',
         ]);
@@ -384,7 +385,7 @@ class BouncerRecordTest extends TestCase
             'original_data' => json_encode(['content' => 'Hello!!!! World']),
         ]);
 
-        $currentEntity = new \Cake\ORM\Entity([
+        $currentEntity = new Entity([
             'modified' => new DateTime('now'),
             'content' => 'Hello World',
         ]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,7 @@ define('APP_DIR', 'src');
 define('TMP', sys_get_temp_dir() . DS);
 define('LOGS', TMP . 'logs' . DS);
 define('CACHE', TMP . 'cache' . DS);
+define('CONFIG', ROOT . DS . 'config' . DS);
 define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp');
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . 'src' . DS);
@@ -29,10 +30,13 @@ require CAKE . 'functions.php';
 
 Configure::write('debug', true);
 Configure::write('App', [
-    'namespace' => 'Bouncer',
+    'namespace' => 'TestApp',
     'encoding' => 'UTF-8',
     'paths' => [
-        'templates' => [ROOT . DS . 'templates' . DS],
+        'templates' => [
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'templates' . DS,
+            ROOT . DS . 'templates' . DS,
+        ],
     ],
 ]);
 

--- a/tests/test_app/src/Application.php
+++ b/tests/test_app/src/Application.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp;
+
+use Cake\Http\BaseApplication;
+use Cake\Http\MiddlewareQueue;
+use Cake\Routing\Middleware\RoutingMiddleware;
+use Cake\Routing\Route\DashedRoute;
+use Cake\Routing\RouteBuilder;
+
+class Application extends BaseApplication
+{
+    /**
+     * @inheritDoc
+     */
+    public function bootstrap(): void
+    {
+        $this->addPlugin('Bouncer', ['routes' => true]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+    {
+        return $middlewareQueue
+            ->add(new RoutingMiddleware($this));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function routes(RouteBuilder $routes): void
+    {
+        $routes->setRouteClass(DashedRoute::class);
+
+        $routes->scope('/', function (RouteBuilder $builder): void {
+            $builder->fallbacks();
+        });
+    }
+}

--- a/tests/test_app/src/View/AppView.php
+++ b/tests/test_app/src/View/AppView.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\View;
+
+use Cake\View\View;
+
+class AppView extends View
+{
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $this->loadHelper('Html');
+        $this->loadHelper('Form');
+        $this->loadHelper('Flash');
+        $this->loadHelper('Number');
+    }
+}

--- a/tests/test_app/templates/Error/error500.php
+++ b/tests/test_app/templates/Error/error500.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Error 500 template for testing
+ */
+?>
+<h2>Error</h2>
+<p><?= h($message) ?></p>

--- a/tests/test_app/templates/element/flash/default.php
+++ b/tests/test_app/templates/element/flash/default.php
@@ -1,0 +1,3 @@
+<?php
+?>
+<div class="alert"><?= h($message) ?></div>

--- a/tests/test_app/templates/element/flash/error.php
+++ b/tests/test_app/templates/element/flash/error.php
@@ -1,0 +1,3 @@
+<?php
+?>
+<div class="alert alert-danger"><?= h($message) ?></div>

--- a/tests/test_app/templates/element/flash/info.php
+++ b/tests/test_app/templates/element/flash/info.php
@@ -1,0 +1,3 @@
+<?php
+?>
+<div class="alert alert-info"><?= h($message) ?></div>

--- a/tests/test_app/templates/element/flash/success.php
+++ b/tests/test_app/templates/element/flash/success.php
@@ -1,0 +1,3 @@
+<?php
+?>
+<div class="alert alert-success"><?= h($message) ?></div>

--- a/tests/test_app/templates/element/flash/warning.php
+++ b/tests/test_app/templates/element/flash/warning.php
@@ -1,0 +1,3 @@
+<?php
+?>
+<div class="alert alert-warning"><?= h($message) ?></div>

--- a/tests/test_app/templates/layout/default.php
+++ b/tests/test_app/templates/layout/default.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Default layout for testing
+ */
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title><?= $this->fetch('title') ?></title>
+</head>
+<body>
+    <?= $this->Flash->render() ?>
+    <?= $this->fetch('content') ?>
+</body>
+</html>

--- a/tests/test_app/templates/layout/error.php
+++ b/tests/test_app/templates/layout/error.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Error layout for testing
+ */
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Error</title>
+</head>
+<body>
+    <?= $this->fetch('content') ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Implements 3-way merge interface for concurrent edits
- Detects when record was modified after draft creation (stale draft)
- Shows diff between: original → current → proposed
- Allows admin to merge changes manually
- Graceful fallback if `original_modified` column doesn't exist (migration not run)

## Changes

1. **Migration**: Adds `original_modified` column to store source record's timestamp when draft is created
2. **BouncerBehavior**: Captures `original_modified` when creating edit/delete drafts
3. **BouncerController**: 
   - `view()` action detects staleness on-demand
   - New `resolve()` action for 3-way merge interface
4. **Templates**: 
   - Warning banner on stale drafts with link to resolve
   - New resolve template with field-by-field merge UI

## Test plan

- [ ] Run migration
- [ ] Create a draft edit for a record
- [ ] Modify the source record directly (bypassing bouncer)
- [ ] View the draft - should show "Stale Draft Detected" warning
- [ ] Click "Resolve Conflicts" to access merge interface
- [ ] Verify 3-way diff shows original, current, and proposed values
- [ ] For conflicting fields, use buttons to select current or proposed value
- [ ] Save merged changes and verify draft is updated
- [ ] Without migration (column missing), verify normal approval flow works