### PR TITLE
Stop event propagation when draft is removed

### DIFF
--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -117,6 +117,12 @@ class BouncerBehavior extends Behavior
                 $this->removeRevertedDraft($entity, $userId);
             }
 
+            // If a draft was removed, stop the save (nothing to save anyway)
+            if ($this->draftRemoved) {
+                $event->stopPropagation();
+                $event->setResult(false);
+            }
+
             return;
         }
 


### PR DESCRIPTION
When a user reverts their changes back to original content and a pending draft is removed, stop the save event to prevent the save from appearing to succeed.

This allows the calling code to properly detect via `wasDraftRemoved()` and show appropriate feedback like "Your proposal has been cancelled" instead of "Changes saved".