### PR TITLE
Add test coverage for formatUser and formatRecord methods

### DIFF
--- a/tests/TestCase/View/Helper/BouncerHelperTest.php
+++ b/tests/TestCase/View/Helper/BouncerHelperTest.php
@@ -126,6 +126,25 @@ class BouncerHelperTest extends TestCase
         $this->assertStringContainsString('No changes detected', $result);
     }
 
+    public function testDiffInlineWithLongText(): void
+    {
+        $diffs = [
+            'description' => [
+                'baseStr' => 'Old text',
+                'proposedStr' => 'New text',
+                'isLongText' => true,
+                'inline' => '<div class="diff-rendered">Inline diff content</div>',
+                'sideBySide' => '<div class="diff-rendered">Side by side content</div>',
+            ],
+        ];
+
+        $result = $this->helper->diffInline($diffs);
+
+        $this->assertStringContainsString('card', $result);
+        $this->assertStringContainsString('description', $result);
+        $this->assertStringContainsString('Inline diff content', $result);
+    }
+
     public function testDiffSideBySideReturnsHtml(): void
     {
         $diffs = [
@@ -142,6 +161,83 @@ class BouncerHelperTest extends TestCase
 
         $this->assertStringContainsString('card', $result);
         $this->assertStringContainsString('content', $result);
+    }
+
+    public function testDiffSideBySideWithEmptyDiffs(): void
+    {
+        $result = $this->helper->diffSideBySide([]);
+
+        $this->assertStringContainsString('No changes detected', $result);
+    }
+
+    public function testDiffSideBySideWithLongText(): void
+    {
+        $diffs = [
+            'body' => [
+                'baseStr' => 'Old body text',
+                'proposedStr' => 'New body text',
+                'isLongText' => true,
+                'inline' => '<div class="diff-inline">Inline</div>',
+                'sideBySide' => '<div class="diff-side">Side by side rendered</div>',
+            ],
+        ];
+
+        $result = $this->helper->diffSideBySide($diffs);
+
+        $this->assertStringContainsString('card', $result);
+        $this->assertStringContainsString('body', $result);
+        $this->assertStringContainsString('Side by side rendered', $result);
+    }
+
+    public function testCalculateDiffsWithLongText(): void
+    {
+        $longText = str_repeat("This is a line of text.\n", 10);
+        $bouncerRecord = new BouncerRecord([
+            'id' => 1,
+            'source' => 'Articles',
+            'primary_key' => 42,
+            'user_id' => 1,
+            'status' => 'pending',
+            'data' => json_encode(['body' => $longText . ' Modified']),
+            'original_data' => json_encode(['body' => $longText]),
+        ]);
+
+        $currentRecord = new Entity([
+            'id' => 42,
+            'body' => $longText,
+        ]);
+
+        $diffs = $this->helper->calculateDiffs($bouncerRecord, $currentRecord);
+
+        $this->assertArrayHasKey('body', $diffs);
+        $this->assertTrue($diffs['body']['isLongText']);
+        $this->assertNotNull($diffs['body']['inline']);
+        $this->assertNotNull($diffs['body']['sideBySide']);
+    }
+
+    public function testCalculateDiffsWithApprovedRecord(): void
+    {
+        $bouncerRecord = new BouncerRecord([
+            'id' => 1,
+            'source' => 'Articles',
+            'primary_key' => 42,
+            'user_id' => 1,
+            'status' => 'approved',
+            'data' => json_encode(['title' => 'New Title']),
+            'original_data' => json_encode(['title' => 'Old Title']),
+        ]);
+
+        // Current record might have changed, but we compare against original_data
+        $currentRecord = new Entity([
+            'id' => 42,
+            'title' => 'Different Title',
+        ]);
+
+        $diffs = $this->helper->calculateDiffs($bouncerRecord, $currentRecord);
+
+        $this->assertArrayHasKey('title', $diffs);
+        $this->assertEquals('Old Title', $diffs['title']['baseStr']);
+        $this->assertEquals('New Title', $diffs['title']['proposedStr']);
     }
 
     public function testNewRecordTable(): void

--- a/tests/TestCase/View/Helper/BouncerHelperTest.php
+++ b/tests/TestCase/View/Helper/BouncerHelperTest.php
@@ -6,6 +6,7 @@ namespace Bouncer\Test\TestCase\View\Helper;
 
 use Bouncer\Model\Entity\BouncerRecord;
 use Bouncer\View\Helper\BouncerHelper;
+use Cake\Core\Configure;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
@@ -270,5 +271,134 @@ class BouncerHelperTest extends TestCase
 
         $this->assertStringContainsString('&lt;script&gt;', $result);
         $this->assertStringNotContainsString('<script>alert', $result);
+    }
+
+    public function testFormatValueWithLongString(): void
+    {
+        $longString = str_repeat('a', 150);
+        $result = $this->helper->formatValue($longString);
+
+        $this->assertStringContainsString('text-break', $result);
+        $this->assertStringContainsString($longString, $result);
+    }
+
+    public function testFormatUserWithNull(): void
+    {
+        $result = $this->helper->formatUser(null);
+
+        $this->assertStringContainsString('N/A', $result);
+        $this->assertStringContainsString('text-muted', $result);
+    }
+
+    public function testFormatUserWithEmptyString(): void
+    {
+        $result = $this->helper->formatUser('');
+
+        $this->assertStringContainsString('N/A', $result);
+    }
+
+    public function testFormatUserWithIdOnly(): void
+    {
+        $result = $this->helper->formatUser(42);
+
+        $this->assertStringContainsString('User #42', $result);
+    }
+
+    public function testFormatUserWithDisplayName(): void
+    {
+        $result = $this->helper->formatUser(42, 'John Doe');
+
+        $this->assertStringContainsString('John Doe', $result);
+        $this->assertStringNotContainsString('User #42', $result);
+    }
+
+    public function testFormatUserWithStringLinkConfig(): void
+    {
+        Configure::write('Bouncer.linkUser', '/admin/users/view/{user}');
+
+        $result = $this->helper->formatUser(42, 'John Doe');
+
+        $this->assertStringContainsString('href="/admin/users/view/42"', $result);
+        $this->assertStringContainsString('John Doe', $result);
+
+        Configure::delete('Bouncer.linkUser');
+    }
+
+    public function testFormatUserWithStringIdLinkConfig(): void
+    {
+        Configure::write('Bouncer.linkUser', '/users/{user}');
+
+        $result = $this->helper->formatUser('123');
+
+        $this->assertStringContainsString('href="/users/123"', $result);
+        $this->assertStringContainsString('User #123', $result);
+
+        Configure::delete('Bouncer.linkUser');
+    }
+
+    public function testFormatUserWithCallableLinkConfig(): void
+    {
+        Configure::write('Bouncer.linkUser', function ($userId) {
+            return '/custom/user/' . $userId;
+        });
+
+        $result = $this->helper->formatUser(99);
+
+        $this->assertStringContainsString('href="/custom/user/99"', $result);
+
+        Configure::delete('Bouncer.linkUser');
+    }
+
+    public function testFormatRecordWithNullPrimaryKey(): void
+    {
+        $result = $this->helper->formatRecord('Articles', null);
+
+        $this->assertStringContainsString('New', $result);
+        $this->assertStringContainsString('badge', $result);
+        $this->assertStringContainsString('bg-success', $result);
+    }
+
+    public function testFormatRecordWithPrimaryKeyNoLink(): void
+    {
+        $result = $this->helper->formatRecord('Articles', 42);
+
+        $this->assertStringContainsString('42', $result);
+        $this->assertStringNotContainsString('href=', $result);
+    }
+
+    public function testFormatRecordWithStringLinkConfig(): void
+    {
+        Configure::write('Bouncer.linkRecord', '/admin/{table}/view/{primary_key}');
+
+        $result = $this->helper->formatRecord('Articles', '42');
+
+        $this->assertStringContainsString('href="/admin/Articles/view/42"', $result);
+        $this->assertStringContainsString('42', $result);
+
+        Configure::delete('Bouncer.linkRecord');
+    }
+
+    public function testFormatRecordWithPluginSource(): void
+    {
+        Configure::write('Bouncer.linkRecord', '/{plugin}/{table}/view/{primary_key}');
+
+        $result = $this->helper->formatRecord('Community.Stories', '99');
+
+        $this->assertStringContainsString('href="/Community/Stories/view/99"', $result);
+
+        Configure::delete('Bouncer.linkRecord');
+    }
+
+    public function testFormatRecordWithCallableLinkConfig(): void
+    {
+        Configure::write('Bouncer.linkRecord', function ($source, $primaryKey, $plugin, $tableName) {
+            return '/records/' . $tableName . '/' . $primaryKey;
+        });
+
+        $result = $this->helper->formatRecord('Articles', '77');
+
+        $this->assertStringContainsString('href="/records/Articles/77"', $result);
+
+        Configure::delete('Bouncer.linkRecord');
     }
 }


### PR DESCRIPTION
## Summary
- Add tests for `formatUser()` method covering:
  - Null and empty user ID handling
  - User ID only display
  - Display name rendering
  - String and callable link configurations

- Add tests for `formatRecord()` method covering:
  - Null primary key (new record badge)
  - Primary key without link config
  - String and callable link configurations
  - Plugin source handling

- Add test for long string formatting in `formatValue()`

These tests cover the previously untested public API methods in BouncerHelper.