### PR TITLE
Add self-contained Bootstrap 5 admin layout and template elements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "cakephp/cakephp": "^5.1.0",
         "phpunit/phpunit": "^11.5.42 || ^12.4.0",
         "php-collective/code-sniffer": "dev-master as 0.4.6",
-        "cakephp/migrations": "^4.0.0"
+        "cakephp/migrations": "^4.0.0",
+        "dereuromark/cakephp-templating": "^0.2.7"
     },
     "suggest": {
         "dereuromark/cakephp-audit-stash": "Integrates seamlessly to provide complete audit trail of approval workflow",

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Bouncer Plugin Configuration
+ *
+ * This file contains configuration options for the Bouncer plugin.
+ */
+
+return [
+    'Bouncer' => [
+        /**
+         * Admin Layout Configuration
+         *
+         * Controls which layout is used for the admin interface:
+         * - null (default): Uses the plugin's isolated Bootstrap 5 layout ('Bouncer.bouncer')
+         *   This is a self-contained layout that doesn't depend on the host application's styling.
+         * - false: Disables the plugin layout, uses the app's default layout.
+         *   Use this when you want to integrate with your existing admin theme.
+         * - string: Uses the specified layout (e.g., 'Admin.default', 'MyTheme.admin')
+         */
+        'adminLayout' => null,
+
+        /**
+         * Standalone Mode
+         *
+         * When enabled, the admin interface operates independently without
+         * inheriting from AppController's authentication/authorization.
+         * Useful for quick setup or when using separate admin authentication.
+         */
+        'standalone' => false,
+
+        /**
+         * User Link Configuration
+         *
+         * Configure how user IDs are linked in the bouncer record display.
+         * - String pattern: '/admin/users/view/{user}' (placeholders: {user}, {display})
+         * - Array URL: ['prefix' => 'Admin', 'controller' => 'Users', 'action' => 'view', '{user}']
+         * - Callable: function($userId, $userDisplay) { return '/admin/users/' . $userId; }
+         * - null: No linking (default)
+         */
+        'linkUser' => null,
+
+        /**
+         * Record Link Configuration
+         *
+         * Configure how source record IDs are linked in the bouncer display.
+         * - String pattern: '/admin/{source}/view/{primary_key}'
+         * - Array URL: ['prefix' => 'Admin', 'controller' => '{source}', 'action' => 'view', '{primary_key}']
+         * - Callable: function($source, $primaryKey) { return [...]; }
+         * - null: No linking (default)
+         */
+        'linkRecord' => null,
+    ],
+];

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -6,6 +6,7 @@ namespace Bouncer\Controller\Admin;
 
 use App\Controller\AppController;
 use Bouncer\Lib\ThreeWayMerge;
+use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use DateTime;
 use Exception;
@@ -18,6 +19,8 @@ use RuntimeException;
  */
 class BouncerController extends AppController
 {
+    use LoadHelperTrait;
+
     /**
      * @var string|null
      */
@@ -33,6 +36,20 @@ class BouncerController extends AppController
     public function beforeFilter(EventInterface $event): void
     {
         parent::beforeFilter($event);
+
+        $this->loadHelpers();
+
+        // Configure layout
+        $adminLayout = Configure::read('Bouncer.adminLayout');
+        if ($adminLayout === false) {
+            // Disable plugin layout, use app's default
+        } elseif ($adminLayout === null) {
+            // Use plugin's isolated Bootstrap 5 layout
+            $this->viewBuilder()->setLayout('Bouncer.bouncer');
+        } else {
+            // Use custom layout
+            $this->viewBuilder()->setLayout($adminLayout);
+        }
     }
 
     /**
@@ -121,7 +138,6 @@ class BouncerController extends AppController
             }
         }
 
-        $this->viewBuilder()->addHelper('Bouncer.Bouncer');
         $this->set(compact('bouncerRecord', 'currentRecord', 'conflict'));
 
         return null;

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bouncer\Controller\Admin;
+
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Templating\View\Helper\IconHelper;
+use Templating\View\Helper\IconSnippetHelper;
+use Templating\View\Helper\TemplatingHelper;
+
+/**
+ * Trait for loading view helpers with graceful fallbacks.
+ *
+ * Detects available plugins and loads appropriate helpers:
+ * - Tools plugin: Time, Text, Format helpers
+ * - Shim plugin: Configure helper
+ * - Templating plugin: Icon, IconSnippet, Templating helpers
+ */
+trait LoadHelperTrait
+{
+    /**
+     * Load helpers with fallbacks based on available plugins.
+     *
+     * @return void
+     */
+    protected function loadHelpers(): void
+    {
+        $helpers = [];
+
+        // Time helper: prefer Tools, fallback to core
+        if (Plugin::isLoaded('Tools')) {
+            $helpers[] = 'Tools.Time';
+            $helpers[] = 'Tools.Text';
+            $helpers[] = 'Tools.Format';
+        } else {
+            $helpers[] = 'Time';
+            $helpers[] = 'Text';
+        }
+
+        // Configure helper: prefer Shim
+        if (Plugin::isLoaded('Shim')) {
+            $helpers[] = 'Shim.Configure';
+        }
+
+        // Templating plugin helpers
+        if (Configure::read('Icon.sets') && class_exists(IconHelper::class)) {
+            $helpers[] = 'Templating.Icon';
+        }
+        if (class_exists(IconSnippetHelper::class)) {
+            $helpers[] = 'Templating.IconSnippet';
+        }
+        if (class_exists(TemplatingHelper::class)) {
+            $helpers[] = 'Templating.Templating';
+        }
+
+        // Always load Bouncer helpers
+        $helpers[] = 'Bouncer.Bouncer';
+
+        $this->viewBuilder()->addHelpers($helpers);
+    }
+}

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Bouncer\Controller\Admin;
 
-use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Templating\View\Helper\IconHelper;
 use Templating\View\Helper\IconSnippetHelper;
 use Templating\View\Helper\TemplatingHelper;
 
@@ -16,7 +14,10 @@ use Templating\View\Helper\TemplatingHelper;
  * Detects available plugins and loads appropriate helpers:
  * - Tools plugin: Time, Text, Format helpers
  * - Shim plugin: Configure helper
- * - Templating plugin: Icon, IconSnippet, Templating helpers
+ * - Templating plugin: IconSnippet, Templating helpers (for yes_no badges etc.)
+ *
+ * Note: The Icon helper is NOT loaded because the plugin layout uses Font Awesome
+ * via CDN, and the Templating Icon helper uses different icon sets.
  */
 trait LoadHelperTrait
 {
@@ -44,10 +45,8 @@ trait LoadHelperTrait
             $helpers[] = 'Shim.Configure';
         }
 
-        // Templating plugin helpers
-        if (Configure::read('Icon.sets') && class_exists(IconHelper::class)) {
-            $helpers[] = 'Templating.Icon';
-        }
+        // Templating plugin helpers (for yes_no badges, etc.)
+        // Note: Icon helper is not loaded - we use Font Awesome via CDN instead
         if (class_exists(IconSnippetHelper::class)) {
             $helpers[] = 'Templating.IconSnippet';
         }

--- a/templates/Admin/Bouncer/index.php
+++ b/templates/Admin/Bouncer/index.php
@@ -38,8 +38,11 @@
                 </div>
                 <div class="col-md-3">
                     <?= $this->Form->control('user_id', [
+                        'type' => 'text',
                         'label' => 'User ID',
                         'default' => $userId,
+                        'placeholder' => 'Search by user ID',
+                        'class' => 'form-control',
                     ]) ?>
                 </div>
                 <div class="col-md-3 d-flex align-items-end">

--- a/templates/element/Bouncer/mobile_nav.php
+++ b/templates/element/Bouncer/mobile_nav.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Bouncer Admin Mobile Navigation
+ *
+ * Offcanvas navigation for mobile devices.
+ *
+ * @var \Cake\View\View $this
+ */
+
+$controller = $this->getRequest()->getParam('controller');
+$action = $this->getRequest()->getParam('action');
+
+$isActive = function (string $c, ?array $actions = null) use ($controller, $action): string {
+    if ($controller !== $c) {
+        return '';
+    }
+    if ($actions === null) {
+        return 'active';
+    }
+
+    return in_array($action, $actions, true) ? 'active' : '';
+};
+?>
+<div class="offcanvas offcanvas-start" tabindex="-1" id="bouncerMobileNav" aria-labelledby="bouncerMobileNavLabel"
+     style="background: linear-gradient(135deg, #1e3a5f 0%, #0d1b2a 100%);">
+    <div class="offcanvas-header border-bottom border-secondary">
+        <h5 class="offcanvas-title text-white" id="bouncerMobileNavLabel">
+            <i class="fas fa-shield-alt me-2"></i>
+            Bouncer
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+        <!-- Navigation -->
+        <div class="mb-4">
+            <div class="text-white-50 small text-uppercase mb-2"><?= __('Navigation') ?></div>
+            <nav class="nav flex-column">
+                <a class="nav-link text-white-50 <?= $isActive('Bouncer', ['index']) ? 'text-white fw-bold' : '' ?>"
+                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+                    <i class="fas fa-list me-2"></i>
+                    <?= __('All Records') ?>
+                </a>
+            </nav>
+        </div>
+
+        <!-- Status Filters -->
+        <div class="mb-4">
+            <div class="text-white-50 small text-uppercase mb-2"><?= __('Status Filters') ?></div>
+            <nav class="nav flex-column">
+                <a class="nav-link text-white-50"
+                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
+                    <i class="fas fa-clock me-2"></i>
+                    <?= __('Pending') ?>
+                </a>
+                <a class="nav-link text-white-50"
+                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
+                    <i class="fas fa-check-circle me-2"></i>
+                    <?= __('Approved') ?>
+                </a>
+                <a class="nav-link text-white-50"
+                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
+                    <i class="fas fa-times-circle me-2"></i>
+                    <?= __('Rejected') ?>
+                </a>
+                <a class="nav-link text-white-50"
+                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
+                    <i class="fas fa-globe me-2"></i>
+                    <?= __('All Statuses') ?>
+                </a>
+            </nav>
+        </div>
+    </div>
+</div>

--- a/templates/element/Bouncer/sidebar.php
+++ b/templates/element/Bouncer/sidebar.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Bouncer Admin Sidebar Navigation
+ *
+ * @var \Cake\View\View $this
+ */
+
+$controller = $this->getRequest()->getParam('controller');
+$action = $this->getRequest()->getParam('action');
+
+$isActive = function (string $c, ?array $actions = null) use ($controller, $action): string {
+    if ($controller !== $c) {
+        return '';
+    }
+    if ($actions === null) {
+        return 'active';
+    }
+
+    return in_array($action, $actions, true) ? 'active' : '';
+};
+?>
+<aside class="bouncer-sidebar d-none d-lg-block">
+    <!-- Navigation -->
+    <div class="nav-section">
+        <div class="nav-section-title"><?= __('Navigation') ?></div>
+        <nav class="nav flex-column">
+            <a class="nav-link <?= $isActive('Bouncer', ['index']) ?>"
+               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+                <?= $this->element('Bouncer.icon', ['name' => 'list', 'fallback' => 'fas fa-list']) ?>
+                <?= __('All Records') ?>
+            </a>
+        </nav>
+    </div>
+
+    <!-- Quick Filters -->
+    <div class="nav-section">
+        <div class="nav-section-title"><?= __('Status Filters') ?></div>
+        <nav class="nav flex-column">
+            <a class="nav-link"
+               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
+                <?= $this->element('Bouncer.icon', ['name' => 'clock', 'fallback' => 'fas fa-clock']) ?>
+                <?= __('Pending') ?>
+            </a>
+            <a class="nav-link"
+               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
+                <?= $this->element('Bouncer.icon', ['name' => 'check-circle', 'fallback' => 'fas fa-check-circle']) ?>
+                <?= __('Approved') ?>
+            </a>
+            <a class="nav-link"
+               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
+                <?= $this->element('Bouncer.icon', ['name' => 'times-circle', 'fallback' => 'fas fa-times-circle']) ?>
+                <?= __('Rejected') ?>
+            </a>
+            <a class="nav-link"
+               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
+                <?= $this->element('Bouncer.icon', ['name' => 'globe', 'fallback' => 'fas fa-globe']) ?>
+                <?= __('All Statuses') ?>
+            </a>
+        </nav>
+    </div>
+</aside>

--- a/templates/element/flash/error.php
+++ b/templates/element/flash/error.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Error flash message element
+ *
+ * @var \Cake\View\View $this
+ */
+
+$flash = $this->getRequest()->getSession()->read('Flash.flash');
+if (!$flash) {
+    return;
+}
+
+foreach ($flash as $message) {
+    if (!isset($message['element']) || $message['element'] !== 'flash/error') {
+        continue;
+    }
+    ?>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <i class="fas fa-exclamation-circle me-2"></i>
+        <?= h($message['message']) ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <?php
+}

--- a/templates/element/flash/info.php
+++ b/templates/element/flash/info.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Info flash message element
+ *
+ * @var \Cake\View\View $this
+ */
+
+$flash = $this->getRequest()->getSession()->read('Flash.flash');
+if (!$flash) {
+    return;
+}
+
+foreach ($flash as $message) {
+    if (!isset($message['element']) || $message['element'] !== 'flash/info') {
+        continue;
+    }
+    ?>
+    <div class="alert alert-info alert-dismissible fade show" role="alert">
+        <i class="fas fa-info-circle me-2"></i>
+        <?= h($message['message']) ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <?php
+}

--- a/templates/element/flash/success.php
+++ b/templates/element/flash/success.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Success flash message element
+ *
+ * @var \Cake\View\View $this
+ */
+
+$flash = $this->getRequest()->getSession()->read('Flash.flash');
+if (!$flash) {
+    return;
+}
+
+foreach ($flash as $message) {
+    if (!isset($message['element']) || $message['element'] !== 'flash/success') {
+        continue;
+    }
+    ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <i class="fas fa-check-circle me-2"></i>
+        <?= h($message['message']) ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <?php
+}

--- a/templates/element/flash/warning.php
+++ b/templates/element/flash/warning.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Warning flash message element
+ *
+ * @var \Cake\View\View $this
+ */
+
+$flash = $this->getRequest()->getSession()->read('Flash.flash');
+if (!$flash) {
+    return;
+}
+
+foreach ($flash as $message) {
+    if (!isset($message['element']) || $message['element'] !== 'flash/warning') {
+        continue;
+    }
+    ?>
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <i class="fas fa-exclamation-triangle me-2"></i>
+        <?= h($message['message']) ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <?php
+}

--- a/templates/element/icon.php
+++ b/templates/element/icon.php
@@ -2,29 +2,21 @@
 /**
  * Icon element with fallbacks
  *
- * Supports Templating plugin's IconHelper when available,
- * falls back to Font Awesome HTML.
+ * Uses Font Awesome icons (loaded via CDN in the plugin layout).
+ * The Templating plugin's Icon helper uses different icon sets (Bootstrap Icons, etc.)
+ * which may not have Font Awesome icon names, so we use Font Awesome directly.
  *
  * @var \Cake\View\View $this
  * @var string $name Icon name
  * @var string|null $fallback Font Awesome class fallback (e.g., 'fas fa-list')
- * @var array $options Additional options for IconHelper
  * @var array $attributes HTML attributes
  */
 
 $name = $name ?? '';
 $fallback = $fallback ?? null;
-$options = $options ?? [];
 $attributes = $attributes ?? [];
 
-// Try Templating plugin's Icon helper
-if ($this->helpers()->has('Icon')) {
-    echo $this->Icon->render($name, $options, $attributes);
-
-    return;
-}
-
-// Font Awesome fallback mapping
+// Font Awesome icon mapping
 $fontAwesomeMap = [
     'list' => 'fas fa-list',
     'clock' => 'fas fa-clock',
@@ -45,6 +37,7 @@ $fontAwesomeMap = [
     'database' => 'fas fa-database',
     'plus' => 'fas fa-plus',
     'minus' => 'fas fa-minus',
+    'clipboard-list' => 'fas fa-clipboard-list',
 ];
 
 $iconClass = $fallback;

--- a/templates/element/icon.php
+++ b/templates/element/icon.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Icon element with fallbacks
+ *
+ * Supports Templating plugin's IconHelper when available,
+ * falls back to Font Awesome HTML.
+ *
+ * @var \Cake\View\View $this
+ * @var string $name Icon name
+ * @var string|null $fallback Font Awesome class fallback (e.g., 'fas fa-list')
+ * @var array $options Additional options for IconHelper
+ * @var array $attributes HTML attributes
+ */
+
+$name = $name ?? '';
+$fallback = $fallback ?? null;
+$options = $options ?? [];
+$attributes = $attributes ?? [];
+
+// Try Templating plugin's Icon helper
+if ($this->helpers()->has('Icon')) {
+    echo $this->Icon->render($name, $options, $attributes);
+
+    return;
+}
+
+// Font Awesome fallback mapping
+$fontAwesomeMap = [
+    'list' => 'fas fa-list',
+    'clock' => 'fas fa-clock',
+    'check-circle' => 'fas fa-check-circle',
+    'times-circle' => 'fas fa-times-circle',
+    'globe' => 'fas fa-globe',
+    'shield-alt' => 'fas fa-shield-alt',
+    'eye' => 'fas fa-eye',
+    'edit' => 'fas fa-edit',
+    'trash' => 'fas fa-trash',
+    'undo' => 'fas fa-undo',
+    'check' => 'fas fa-check',
+    'times' => 'fas fa-times',
+    'exclamation-triangle' => 'fas fa-exclamation-triangle',
+    'exclamation-circle' => 'fas fa-exclamation-circle',
+    'info-circle' => 'fas fa-info-circle',
+    'user' => 'fas fa-user',
+    'database' => 'fas fa-database',
+    'plus' => 'fas fa-plus',
+    'minus' => 'fas fa-minus',
+];
+
+$iconClass = $fallback;
+if (!$iconClass && isset($fontAwesomeMap[$name])) {
+    $iconClass = $fontAwesomeMap[$name];
+}
+
+if ($iconClass) {
+    $attrString = '';
+    foreach ($attributes as $key => $value) {
+        $attrString .= ' ' . h($key) . '="' . h($value) . '"';
+    }
+    echo '<i class="' . h($iconClass) . ' me-2"' . $attrString . '></i>';
+} else {
+    // Last resort: text label
+    echo '[' . h($name) . ']';
+}

--- a/templates/element/yes_no.php
+++ b/templates/element/yes_no.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Yes/No boolean badge element with fallbacks
+ *
+ * Supports Templating plugin helpers when available,
+ * falls back to Bootstrap 5 badges.
+ *
+ * @var \Cake\View\View $this
+ * @var bool $value Boolean value to display
+ * @var array $options Additional options
+ */
+
+$value = $value ?? false;
+$options = $options ?? [];
+
+$yesLabel = $options['yesLabel'] ?? __('Yes');
+$noLabel = $options['noLabel'] ?? __('No');
+
+// Try Templating plugin's helper
+if ($this->helpers()->has('Templating')) {
+    echo $this->Templating->yesNo($value, $options);
+
+    return;
+}
+
+// Try IconSnippet helper
+if ($this->helpers()->has('IconSnippet')) {
+    echo $this->IconSnippet->yesNo($value, $options);
+
+    return;
+}
+
+// Try Format helper from Tools plugin
+if ($this->helpers()->has('Format')) {
+    echo $this->Format->yesNo($value, $options);
+
+    return;
+}
+
+// Bootstrap 5 fallback
+if ($value) {
+    echo '<span class="badge bg-success">' . h($yesLabel) . '</span>';
+} else {
+    echo '<span class="badge bg-secondary">' . h($noLabel) . '</span>';
+}

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * Bouncer Admin Layout
+ *
+ * Self-contained Bootstrap 5 layout for the Bouncer admin interface.
+ * Uses CDN resources to avoid conflicts with host application styling.
+ *
+ * @var \Cake\View\View $this
+ */
+
+use Cake\Core\Configure;
+
+$controller = $this->getRequest()->getParam('controller');
+$action = $this->getRequest()->getParam('action');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <?= $this->Html->charset() ?>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= $this->fetch('title') ? $this->fetch('title') . ' - ' : '' ?>Bouncer Admin</title>
+
+    <!-- Bootstrap 5 CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    <style>
+        :root {
+            --bouncer-primary: #0d6efd;
+            --bouncer-primary-light: #3d8bfd;
+            --bouncer-primary-dark: #0a58ca;
+            --bouncer-success: #198754;
+            --bouncer-warning: #ffc107;
+            --bouncer-danger: #dc3545;
+            --bouncer-info: #0dcaf0;
+            --bouncer-secondary: #6c757d;
+            --bouncer-dark: #212529;
+            --bouncer-light: #f8f9fa;
+            --bouncer-sidebar-bg: linear-gradient(135deg, #1e3a5f 0%, #0d1b2a 100%);
+            --bouncer-sidebar-width: 260px;
+            --bouncer-header-height: 56px;
+        }
+
+        body {
+            background-color: #f5f6fa;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            min-height: 100vh;
+        }
+
+        /* Header */
+        .bouncer-header {
+            background: var(--bouncer-sidebar-bg);
+            height: var(--bouncer-header-height);
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1030;
+            display: flex;
+            align-items: center;
+            padding: 0 1rem;
+        }
+
+        .bouncer-header .navbar-brand {
+            color: #fff;
+            font-weight: 600;
+            font-size: 1.1rem;
+        }
+
+        .bouncer-header .navbar-brand:hover {
+            color: rgba(255, 255, 255, 0.9);
+        }
+
+        .bouncer-header .navbar-brand i {
+            margin-right: 0.5rem;
+        }
+
+        /* Sidebar */
+        .bouncer-sidebar {
+            position: fixed;
+            top: var(--bouncer-header-height);
+            left: 0;
+            bottom: 0;
+            width: var(--bouncer-sidebar-width);
+            background: var(--bouncer-sidebar-bg);
+            padding: 1rem 0;
+            overflow-y: auto;
+            z-index: 1020;
+        }
+
+        .bouncer-sidebar .nav-section {
+            padding: 0 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .bouncer-sidebar .nav-section-title {
+            color: rgba(255, 255, 255, 0.5);
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.5rem;
+            padding: 0 0.75rem;
+        }
+
+        .bouncer-sidebar .nav-link {
+            color: rgba(255, 255, 255, 0.8);
+            padding: 0.5rem 0.75rem;
+            border-radius: 0.375rem;
+            margin-bottom: 0.25rem;
+            transition: all 0.15s ease;
+        }
+
+        .bouncer-sidebar .nav-link:hover {
+            color: #fff;
+            background: rgba(255, 255, 255, 0.1);
+        }
+
+        .bouncer-sidebar .nav-link.active {
+            color: #fff;
+            background: rgba(255, 255, 255, 0.15);
+            font-weight: 500;
+        }
+
+        .bouncer-sidebar .nav-link i {
+            width: 1.25rem;
+            margin-right: 0.5rem;
+            text-align: center;
+        }
+
+        /* Main content */
+        .bouncer-main {
+            margin-left: var(--bouncer-sidebar-width);
+            margin-top: var(--bouncer-header-height);
+            padding: 1.5rem;
+            min-height: calc(100vh - var(--bouncer-header-height));
+        }
+
+        @media (max-width: 991.98px) {
+            .bouncer-sidebar {
+                display: none;
+            }
+            .bouncer-main {
+                margin-left: 0;
+            }
+        }
+
+        /* Cards */
+        .card {
+            border: none;
+            box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+            border-radius: 0.5rem;
+        }
+
+        .card-header {
+            background-color: #fff;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+            font-weight: 600;
+        }
+
+        /* Stats cards */
+        .stats-card {
+            padding: 1.25rem;
+            border-radius: 0.5rem;
+            background: #fff;
+            box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+        }
+
+        .stats-card .stats-value {
+            font-size: 2rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .stats-card .stats-label {
+            font-size: 0.875rem;
+            color: var(--bouncer-secondary);
+            margin-top: 0.25rem;
+        }
+
+        /* Table styling */
+        .table {
+            margin-bottom: 0;
+        }
+
+        .table th {
+            border-top: none;
+            font-weight: 600;
+            font-size: 0.875rem;
+            color: var(--bouncer-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .table td {
+            vertical-align: middle;
+        }
+
+        /* Badges */
+        .badge {
+            font-weight: 500;
+            padding: 0.35em 0.65em;
+        }
+
+        /* Pagination */
+        .pagination {
+            margin-bottom: 0.5rem;
+        }
+
+        .pagination .page-link {
+            border-radius: 0.375rem;
+            margin: 0 0.125rem;
+            border: none;
+            color: var(--bouncer-primary);
+        }
+
+        .pagination .page-item.active .page-link {
+            background-color: var(--bouncer-primary);
+            border-color: var(--bouncer-primary);
+        }
+
+        /* Footer */
+        .bouncer-footer {
+            padding: 1rem 0;
+            font-size: 0.875rem;
+            color: var(--bouncer-secondary);
+            border-top: 1px solid rgba(0, 0, 0, 0.05);
+            margin-top: 2rem;
+        }
+
+        /* Flash messages */
+        .alert {
+            border: none;
+            border-radius: 0.5rem;
+        }
+
+        /* Mobile nav toggle */
+        .mobile-nav-toggle {
+            display: none;
+            color: #fff;
+            background: transparent;
+            border: none;
+            font-size: 1.25rem;
+            padding: 0.5rem;
+        }
+
+        @media (max-width: 991.98px) {
+            .mobile-nav-toggle {
+                display: block;
+            }
+        }
+
+        /* Diff styles */
+        .diff-wrapper { width: 100%; border-collapse: collapse; font-family: monospace; font-size: 13px; }
+        .diff-wrapper th, .diff-wrapper td { padding: 4px 8px; border: 1px solid #dee2e6; vertical-align: top; }
+        .diff-wrapper .line-num { width: 40px; background: #f8f9fa; color: #6c757d; text-align: right; user-select: none; }
+        .diff-wrapper tr.unchanged td { background: #f8f9fa; }
+        .diff-wrapper tr.added td { background: #e6ffec; }
+        .diff-wrapper tr.removed td { background: #ffebe9; }
+        .diff-wrapper tr.changed td { background: #fef6d9; }
+        .diff-wrapper ins { background: #94f094; text-decoration: none; padding: 1px 2px; font-weight: bold; }
+        .diff-wrapper del { background: #f09494; text-decoration: none; padding: 1px 2px; font-weight: bold; }
+        .diff-wrapper .old { background-color: #ffebe9; }
+        .diff-wrapper .new { background-color: #e6ffec; }
+        pre { background-color: #f8f9fa; padding: 0.5rem; border-radius: 0.25rem; }
+    </style>
+    <?= $this->fetch('css') ?>
+</head>
+<body>
+    <!-- Header -->
+    <header class="bouncer-header">
+        <button class="mobile-nav-toggle me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#bouncerMobileNav">
+            <i class="fas fa-bars"></i>
+        </button>
+        <a class="navbar-brand" href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+            <i class="fas fa-shield-alt"></i>
+            Bouncer Admin
+        </a>
+    </header>
+
+    <!-- Sidebar -->
+    <?= $this->element('Bouncer.Bouncer/sidebar') ?>
+
+    <!-- Mobile Navigation -->
+    <?= $this->element('Bouncer.Bouncer/mobile_nav') ?>
+
+    <!-- Main Content -->
+    <main class="bouncer-main">
+        <!-- Flash messages -->
+        <?= $this->element('Bouncer.flash/success') ?>
+        <?= $this->element('Bouncer.flash/error') ?>
+        <?= $this->element('Bouncer.flash/warning') ?>
+        <?= $this->element('Bouncer.flash/info') ?>
+
+        <?= $this->fetch('content') ?>
+
+        <!-- Footer -->
+        <footer class="bouncer-footer">
+            <div class="d-flex justify-content-between align-items-center">
+                <span>Bouncer Plugin</span>
+                <span>PHP <?= PHP_VERSION ?></span>
+            </div>
+        </footer>
+    </main>
+
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Initialize tooltips
+        var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+        tooltipTriggerList.map(function (tooltipTriggerEl) {
+            return new bootstrap.Tooltip(tooltipTriggerEl);
+        });
+
+        // Form confirmation
+        document.querySelectorAll('form[data-confirm]').forEach(function(form) {
+            form.addEventListener('submit', function(e) {
+                if (!confirm(form.dataset.confirm)) {
+                    e.preventDefault();
+                }
+            });
+        });
+    });
+    </script>
+    <?= $this->fetch('script') ?>
+    <?= $this->fetch('postLink') ?>
+</body>
+</html>

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -207,7 +207,8 @@ $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
 
         /* Pagination */
         .pagination {
-            margin-bottom: 0.5rem;
+            margin-top: 1rem;
+            margin-bottom: 1rem;
         }
 
         .pagination .page-link {

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -9,9 +9,11 @@
  */
 
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 
 $controller = $this->getRequest()->getParam('controller');
 $action = $this->getRequest()->getParam('action');
+$hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -277,6 +279,12 @@ $action = $this->getRequest()->getParam('action');
             <i class="fas fa-shield-alt"></i>
             Bouncer Admin
         </a>
+        <?php if ($hasAuditStashPlugin) { ?>
+        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build(['plugin' => 'AuditStash', 'prefix' => 'Admin', 'controller' => 'AuditLogs', 'action' => 'index']) ?>">
+            <i class="fas fa-clipboard-list me-1"></i>
+            AuditStash
+        </a>
+        <?php } ?>
     </header>
 
     <!-- Sidebar -->


### PR DESCRIPTION
## Summary

Similar to cakephp-queue and cakephp-queue-scheduler, this adds proper own templating with a self-contained admin interface that doesn't depend on the host application's styling.

### New files:
- `templates/layout/bouncer.php` - Isolated Bootstrap 5 layout with CDN assets (Bootstrap 5.3.3, Font Awesome 6.7.2), responsive sidebar, and mobile offcanvas navigation
- `templates/element/Bouncer/sidebar.php` - Navigation sidebar with status filter links
- `templates/element/Bouncer/mobile_nav.php` - Offcanvas mobile menu for responsive design
- `templates/element/flash/*.php` - Styled flash message elements (success, error, warning, info)
- `templates/element/icon.php` - Icon element with Templating plugin fallback to Font Awesome
- `templates/element/yes_no.php` - Boolean badge element with fallback chain (Templating -> Format -> Bootstrap)
- `src/Controller/Admin/LoadHelperTrait.php` - Smart helper loading with fallbacks for Tools, Shim, and Templating plugins
- `config/app.example.php` - Configuration documentation

### Updated files:
- `BouncerController` - Uses LoadHelperTrait, configurable layout via beforeFilter, removed manual helper loading from view method
- `composer.json` - Added dereuromark/cakephp-templating to require-dev

### Configuration options:
- `Bouncer.adminLayout`: `null` (plugin's isolated layout), `false` (use app's layout), or custom layout string
- `Bouncer.standalone`: `bool` for independent admin operation without inheriting AppController auth
- `Bouncer.linkUser`: Configure how user IDs are linked (string pattern, array URL, or callable)
- `Bouncer.linkRecord`: Configure how source record IDs are linked