### PR TITLE
Use dynamic plugin and prefix in admin layout templates

### DIFF
--- a/templates/element/Bouncer/mobile_nav.php
+++ b/templates/element/Bouncer/mobile_nav.php
@@ -9,6 +9,8 @@
 
 $controller = $this->getRequest()->getParam('controller');
 $action = $this->getRequest()->getParam('action');
+$plugin = $this->getRequest()->getParam('plugin');
+$prefix = $this->getRequest()->getParam('prefix');
 
 $isActive = function (string $c, ?array $actions = null) use ($controller, $action): string {
     if ($controller !== $c) {
@@ -36,7 +38,7 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
             <div class="text-white-50 small text-uppercase mb-2"><?= __('Navigation') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50 <?= $isActive('Bouncer', ['index']) ? 'text-white fw-bold' : '' ?>"
-                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
                     <i class="fas fa-list me-2"></i>
                     <?= __('All Records') ?>
                 </a>
@@ -48,22 +50,22 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
             <div class="text-white-50 small text-uppercase mb-2"><?= __('Status Filters') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50"
-                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
+                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
                     <i class="fas fa-clock me-2"></i>
                     <?= __('Pending') ?>
                 </a>
                 <a class="nav-link text-white-50"
-                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
+                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
                     <i class="fas fa-check-circle me-2"></i>
                     <?= __('Approved') ?>
                 </a>
                 <a class="nav-link text-white-50"
-                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
+                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
                     <i class="fas fa-times-circle me-2"></i>
                     <?= __('Rejected') ?>
                 </a>
                 <a class="nav-link text-white-50"
-                   href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
+                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
                     <i class="fas fa-globe me-2"></i>
                     <?= __('All Statuses') ?>
                 </a>

--- a/templates/element/Bouncer/sidebar.php
+++ b/templates/element/Bouncer/sidebar.php
@@ -7,6 +7,8 @@
 
 $controller = $this->getRequest()->getParam('controller');
 $action = $this->getRequest()->getParam('action');
+$plugin = $this->getRequest()->getParam('plugin');
+$prefix = $this->getRequest()->getParam('prefix');
 
 $isActive = function (string $c, ?array $actions = null) use ($controller, $action): string {
     if ($controller !== $c) {
@@ -25,7 +27,7 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
         <div class="nav-section-title"><?= __('Navigation') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link <?= $isActive('Bouncer', ['index']) ?>"
-               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'list', 'fallback' => 'fas fa-list']) ?>
                 <?= __('All Records') ?>
             </a>
@@ -37,22 +39,22 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
         <div class="nav-section-title"><?= __('Status Filters') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link"
-               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
+               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'clock', 'fallback' => 'fas fa-clock']) ?>
                 <?= __('Pending') ?>
             </a>
             <a class="nav-link"
-               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
+               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'check-circle', 'fallback' => 'fas fa-check-circle']) ?>
                 <?= __('Approved') ?>
             </a>
             <a class="nav-link"
-               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
+               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'times-circle', 'fallback' => 'fas fa-times-circle']) ?>
                 <?= __('Rejected') ?>
             </a>
             <a class="nav-link"
-               href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
+               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'globe', 'fallback' => 'fas fa-globe']) ?>
                 <?= __('All Statuses') ?>
             </a>

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -13,6 +13,8 @@ use Cake\Core\Plugin;
 
 $controller = $this->getRequest()->getParam('controller');
 $action = $this->getRequest()->getParam('action');
+$plugin = $this->getRequest()->getParam('plugin');
+$prefix = $this->getRequest()->getParam('prefix');
 $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
 ?>
 <!DOCTYPE html>
@@ -276,12 +278,12 @@ $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
         <button class="mobile-nav-toggle me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#bouncerMobileNav">
             <i class="fas fa-bars"></i>
         </button>
-        <a class="navbar-brand" href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+        <a class="navbar-brand" href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
             <i class="fas fa-shield-alt"></i>
             Bouncer Admin
         </a>
         <?php if ($hasAuditStashPlugin) { ?>
-        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build(['plugin' => 'AuditStash', 'prefix' => 'Admin', 'controller' => 'AuditLogs', 'action' => 'index']) ?>">
+        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build(['plugin' => 'AuditStash', 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index']) ?>">
             <i class="fas fa-clipboard-list me-1"></i>
             AuditStash
         </a>


### PR DESCRIPTION
## Summary

- Retrieves `plugin` and `prefix` from the current request instead of hardcoding `'Bouncer'` and `'Admin'`
- Applies to the main layout, sidebar, and mobile nav elements
- Allows using the admin layout with custom prefixes or no prefix

Related to dereuromark/cakephp-audit-stash#36