### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/Bouncer/view.php
+++ b/templates/Admin/Bouncer/view.php
@@ -167,10 +167,16 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
             </div>
             <div class="card-body">
                 <p class="text-muted"><?= __('This proposal was rejected.') ?></p>
-                <?= $this->Form->postLink(
+                <?= $this->Form->postButton(
                     __('Reopen for Review'),
                     ['action' => 'reopen', $bouncerRecord->id],
-                    ['class' => 'btn btn-warning', 'confirm' => __('Are you sure you want to reopen this proposal?')]
+                    [
+                        'class' => 'btn btn-warning',
+                        'form' => [
+                            'class' => 'd-inline',
+                            'data-confirm-message' => __('Are you sure you want to reopen this proposal?'),
+                        ],
+                    ]
                 ) ?>
             </div>
         </div>

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -16,6 +16,7 @@ $action = $this->getRequest()->getParam('action');
 $plugin = $this->getRequest()->getParam('plugin');
 $prefix = $this->getRequest()->getParam('prefix');
 $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -315,7 +316,7 @@ $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
-    <script>
+    <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
     document.addEventListener('DOMContentLoaded', function() {
         // Initialize tooltips
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
@@ -323,10 +324,10 @@ $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
             return new bootstrap.Tooltip(tooltipTriggerEl);
         });
 
-        // Form confirmation
-        document.querySelectorAll('form[data-confirm]').forEach(function(form) {
+        // Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
+        document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
             form.addEventListener('submit', function(e) {
-                if (!confirm(form.dataset.confirm)) {
+                if (!confirm(form.dataset.confirmMessage)) {
                     e.preventDefault();
                 }
             });


### PR DESCRIPTION
## Summary

- Add nonce attribute to the layout's inline `<script>` block.
- Replace the single `Form->postLink` + `confirm` with `Form->postButton` + `data-confirm-message`.
- Update the layout's existing delegated submit listener to hook `form[data-confirm-message]` instead of the legacy `form[data-confirm]` (no templates used the old selector).

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- Add `nonce` attribute to 1 inline `<script>` block in `templates/layout/bouncer.php`.
- Replace 1 `Form->postLink` call with `Form->postButton` (preserves the confirmation UX via `form[data-confirm-message]` + the JS delegate in the layout).

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->postLink(
-     __('Reopen for Review'),
-     ['action' => 'reopen', $bouncerRecord->id],
-     ['class' => 'btn btn-warning', 'confirm' => __('Are you sure you want to reopen this proposal?')]
- ) ?>
+ <?= $this->Form->postButton(
+     __('Reopen for Review'),
+     ['action' => 'reopen', $bouncerRecord->id],
+     [
+         'class' => 'btn btn-warning',
+         'form' => [
+             'class' => 'd-inline',
+             'data-confirm-message' => __('Are you sure you want to reopen this proposal?'),
+         ],
+     ]
+ ) ?>
```
