### PR TITLE
Move mobile-nav background to CSS class (strict-CSP)

### DIFF
--- a/templates/element/Bouncer/mobile_nav.php
+++ b/templates/element/Bouncer/mobile_nav.php
@@ -23,8 +23,7 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
     return in_array($action, $actions, true) ? 'active' : '';
 };
 ?>
-<div class="offcanvas offcanvas-start" tabindex="-1" id="bouncerMobileNav" aria-labelledby="bouncerMobileNavLabel"
-     style="background: linear-gradient(135deg, #1e3a5f 0%, #0d1b2a 100%);">
+<div class="offcanvas offcanvas-start bouncer-mobile-nav-bg" tabindex="-1" id="bouncerMobileNav" aria-labelledby="bouncerMobileNavLabel">
     <div class="offcanvas-header border-bottom border-secondary">
         <h5 class="offcanvas-title text-white" id="bouncerMobileNavLabel">
             <i class="fas fa-shield-alt me-2"></i>

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -94,6 +94,11 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             z-index: 1020;
         }
 
+        /* Mobile nav offcanvas — same background as sidebar */
+        .bouncer-mobile-nav-bg {
+            background: var(--bouncer-sidebar-bg);
+        }
+
         .bouncer-sidebar .nav-section {
             padding: 0 1rem;
             margin-bottom: 1.5rem;


### PR DESCRIPTION
## Summary

Drops the inline `style="background: linear-gradient(...)"` attribute on the mobile-nav offcanvas in favour of a `.bouncer-mobile-nav-bg` class defined in the layout's existing `<style>` block. The class reuses the existing `--bouncer-sidebar-bg` custom property, so the visual is unchanged.

This removes the `style-src 'unsafe-inline'` requirement for this element. Fully strict-CSP compatibility for the rest of the layout (the inline `<style>` block itself, and the various `<th style="width:...">` widths in `Admin/Bouncer/resolve.php`) is a follow-up.

## Files changed

- `templates/layout/bouncer.php` — add `.bouncer-mobile-nav-bg` rule
- `templates/element/Bouncer/mobile_nav.php` — replace `style=` with `class=`