### PR TITLE
Drop leftover inline styles in resolve.php (strict-CSP)

### DIFF
--- a/templates/Admin/Bouncer/resolve.php
+++ b/templates/Admin/Bouncer/resolve.php
@@ -62,12 +62,12 @@ $hasConflicts = !empty($conflict['conflicts']);
                     <table class="table table-bordered table-sm">
                         <thead class="table-light">
                             <tr>
-                                <th style="width: 12%"><?= __('Field') ?></th>
-                                <th style="width: 18%"><?= __('Original') ?></th>
-                                <th style="width: 18%"><?= __('Current') ?></th>
-                                <th style="width: 18%"><?= __('Proposed') ?></th>
-                                <th style="width: 18%"><?= __('Merged Result') ?></th>
-                                <th style="width: 16%"><?= __('Changes') ?></th>
+                                <th class="bouncer-col-w-12"><?= __('Field') ?></th>
+                                <th class="bouncer-col-w-18"><?= __('Original') ?></th>
+                                <th class="bouncer-col-w-18"><?= __('Current') ?></th>
+                                <th class="bouncer-col-w-18"><?= __('Proposed') ?></th>
+                                <th class="bouncer-col-w-18"><?= __('Merged Result') ?></th>
+                                <th class="bouncer-col-w-16"><?= __('Changes') ?></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -127,11 +127,11 @@ $hasConflicts = !empty($conflict['conflicts']);
                     <table class="table table-bordered table-sm">
                         <thead class="table-light">
                             <tr>
-                                <th style="width: 15%"><?= __('Field') ?></th>
-                                <th style="width: 20%"><?= __('Original') ?></th>
-                                <th style="width: 20%"><?= __('Current') ?></th>
-                                <th style="width: 20%"><?= __('Proposed') ?></th>
-                                <th style="width: 25%"><?= __('Choose Value') ?></th>
+                                <th class="bouncer-col-w-15"><?= __('Field') ?></th>
+                                <th class="bouncer-col-w-20"><?= __('Original') ?></th>
+                                <th class="bouncer-col-w-20"><?= __('Current') ?></th>
+                                <th class="bouncer-col-w-20"><?= __('Proposed') ?></th>
+                                <th class="bouncer-col-w-25"><?= __('Choose Value') ?></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/templates/Admin/Bouncer/view.php
+++ b/templates/Admin/Bouncer/view.php
@@ -118,7 +118,7 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
                 <div id="inline-diff-view">
                     <?= $this->Bouncer->diffInline($diffs) ?>
                 </div>
-                <div id="side-diff-view" style="display: none;">
+                <div id="side-diff-view" hidden>
                     <?= $this->Bouncer->diffSideBySide($diffs) ?>
                 </div>
             <?php } else { ?>

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -99,6 +99,15 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             background: var(--bouncer-sidebar-bg);
         }
 
+        /* Column-width utilities for Admin/Bouncer/resolve.php diff tables
+           (replace inline `<th style="width:N%">` with strict-CSP-safe classes). */
+        .bouncer-col-w-12 { width: 12%; }
+        .bouncer-col-w-15 { width: 15%; }
+        .bouncer-col-w-16 { width: 16%; }
+        .bouncer-col-w-18 { width: 18%; }
+        .bouncer-col-w-20 { width: 20%; }
+        .bouncer-col-w-25 { width: 25%; }
+
         .bouncer-sidebar .nav-section {
             padding: 0 1rem;
             margin-bottom: 1.5rem;


### PR DESCRIPTION
Follow-up to #17. Replaces the 11 `<th style="width:N%">` attributes in `Admin/Bouncer/resolve.php` and the `style="display:none;"` on `#side-diff-view` with strict-CSP-safe alternatives — `.bouncer-col-w-N` classes in the layout and the HTML5 `hidden` attribute respectively. Templates now have zero inline `style=` attributes.