### PR TITLE
Add Bouncer.accessCheck Closure gate (opt-in defense-in-depth)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,12 +68,35 @@ $routes->prefix('Admin', function (RouteBuilder $routes) {
 
 ### 4. Access Admin Interface
 
-Navigate to \`/admin/bouncer/bouncer\` to review pending changes:
+Navigate to `/admin/bouncer/bouncer` to review pending changes:
 - Filter by status, table, or user
 - View side-by-side diff of changes
 - Approve or reject with optional reason/note
 
 That's it! Your table now requires approval for all changes.
+
+### 5. (Optional) Tighten admin access via `Bouncer.accessCheck`
+
+The admin UI inherits the host application's `AppController` auth. If your
+app already gates `/admin/*` for admins, no further setup is needed. For
+defense-in-depth — e.g. "moderators only, not all admins" — set
+`Bouncer.accessCheck` to a `Closure` that returns literal `true` to grant
+access. Anything else (returns `false`, returns a truthy non-bool, throws)
+yields a `403`.
+
+```php
+use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
+
+Configure::write('Bouncer.accessCheck', function (ServerRequest $request): bool {
+    $identity = $request->getAttribute('identity');
+    return $identity !== null && in_array('moderator', (array)$identity->roles, true);
+});
+```
+
+Unset = no-op (host auth alone applies). The gate calls
+`Authorization::skipAuthorization()` when the cakephp/authorization
+component is loaded so the policy layer doesn't double-reject.
 
 ## Configuration Options
 

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -8,9 +8,13 @@ use App\Controller\AppController;
 use Bouncer\Lib\ThreeWayMerge;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Log\Log;
+use Closure;
 use DateTime;
 use Exception;
 use RuntimeException;
+use Throwable;
 
 /**
  * Bouncer Controller
@@ -37,6 +41,7 @@ class BouncerController extends AppController
     {
         parent::beforeFilter($event);
 
+        $this->enforceAccessCheck();
         $this->loadHelpers();
 
         // Configure layout
@@ -49,6 +54,52 @@ class BouncerController extends AppController
         } else {
             // Use custom layout
             $this->viewBuilder()->setLayout($adminLayout);
+        }
+    }
+
+    /**
+     * Optional defense-in-depth access gate.
+     *
+     * Bouncer manages content moderation / conflict resolution rules — useful
+     * to tighten beyond the host AppController's auth (e.g. "moderators only,
+     * not all admins"). Set `Bouncer.accessCheck` to a Closure that receives
+     * the current request and returns literal `true` to grant access; anything
+     * else (returns false, returns a truthy non-bool, throws) yields a 403.
+     *
+     * Unset = no-op (host AppController auth alone applies).
+     *
+     * @throws \Cake\Http\Exception\ForbiddenException When the configured Closure rejects the request.
+     *
+     * @return void
+     */
+    protected function enforceAccessCheck(): void
+    {
+        $check = Configure::read('Bouncer.accessCheck');
+        if ($check === null) {
+            return;
+        }
+        if (!($check instanceof Closure)) {
+            throw new ForbiddenException('Bouncer.accessCheck must be a Closure');
+        }
+
+        // Coexist with cakephp/authorization: the gate IS the authorization
+        // decision, so silence the policy check.
+        if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+            $this->components()->get('Authorization')->skipAuthorization();
+        }
+
+        try {
+            $allowed = $check($this->request) === true;
+        } catch (ForbiddenException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            Log::warning(sprintf('Bouncer.accessCheck threw %s: %s', $e::class, $e->getMessage()));
+
+            throw new ForbiddenException('Bouncer admin access denied');
+        }
+
+        if (!$allowed) {
+            throw new ForbiddenException('Bouncer admin access denied');
         }
     }
 

--- a/tests/TestCase/Controller/Admin/BouncerControllerTest.php
+++ b/tests/TestCase/Controller/Admin/BouncerControllerTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Bouncer\Test\TestCase\Controller\Admin;
 
+use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\I18n\DateTime;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 /**
  * Bouncer\Controller\Admin\BouncerController Test Case
@@ -62,8 +65,91 @@ class BouncerControllerTest extends TestCase
     protected function tearDown(): void
     {
         unset($this->BouncerRecords, $this->Articles);
+        Configure::delete('Bouncer.accessCheck');
 
         parent::tearDown();
+    }
+
+    public function testAccessCheckUnsetIsNoOp(): void
+    {
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+
+        $this->assertResponseOk();
+    }
+
+    public function testAccessCheckNonClosureRejects(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('Bouncer.accessCheck', 'not a closure');
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+    }
+
+    public function testAccessCheckClosureFalseRejects(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('Bouncer.accessCheck', fn () => false);
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+    }
+
+    public function testAccessCheckRequiresStrictTrue(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('Bouncer.accessCheck', fn () => 1);
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+    }
+
+    public function testAccessCheckClosureTrueAllows(): void
+    {
+        Configure::write('Bouncer.accessCheck', fn () => true);
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+
+        $this->assertResponseOk();
+    }
+
+    public function testAccessCheckThrowingYields403(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('Bouncer.accessCheck', function (): bool {
+            throw new RuntimeException('oops');
+        });
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+    }
+
+    public function testAccessCheckExplicitForbiddenIsRespected(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('Bouncer.accessCheck', function (): bool {
+            throw new ForbiddenException('custom denial reason');
+        });
+
+        $this->expectException(ForbiddenException::class);
+        $this->expectExceptionMessage('custom denial reason');
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+    }
+
+    public function testAccessCheckReceivesRequest(): void
+    {
+        $received = null;
+        Configure::write('Bouncer.accessCheck', function ($request) use (&$received): bool {
+            $received = $request;
+
+            return true;
+        });
+
+        $this->get(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'index']);
+
+        $this->assertResponseOk();
+        $this->assertNotNull($received);
+        $this->assertStringContainsString('bouncer', $received->getPath());
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds an optional `Bouncer.accessCheck` Closure gate to the admin backend at `/admin/bouncer`. Defense-in-depth on top of whatever auth the host `AppController` provides; unset = no-op (current behavior preserved). **Non-breaking.**

## Why

The admin UI inherits host `AppController` auth by default. The new knob is for hosts that want to tighten beyond the default — for example, "this content-moderation backend is for moderators only, not every admin user." The plugin can't infer that distinction from the host setup, so it has to be explicit.

## Behavior

- **Unset** (default) → no-op. Host auth alone applies. **No breaking change.**
- **Non-`Closure` value** (e.g. accidental string) → `403`. Misconfigured key fails closed.
- **`Closure` returns literal `true`** → request proceeds.
- **`Closure` returns `false` / truthy non-bool** → `403`.
- **`Closure` throws `ForbiddenException`** → respected as-is (caller can short-circuit with their own message).
- **`Closure` throws any other `Throwable`** → logged via `Cake\Log\Log` and converted to a generic `403`.

Calls `Authorization::skipAuthorization()` when the cakephp/authorization component is loaded so the gate doesn't conflict with policy-based authorization.

## Example

```php
use Cake\Core\Configure;
use Cake\Http\ServerRequest;

Configure::write('Bouncer.accessCheck', function (ServerRequest $request): bool {
    $identity = $request->getAttribute('identity');
    return $identity !== null && in_array('moderator', (array)$identity->roles, true);
});
```

## Tests

8 new cases in `BouncerControllerTest` cover all branches. All 203 existing tests still pass.

## Checklist

- [x] phpunit (203/203)
- [x] phpcs clean
- [x] phpstan: no new errors (one pre-existing in `BouncerController.php:447` unchanged on master)
- [x] Docs updated (`docs/README.md` step 5)
