### PR TITLE
Use escapeTitle in pagination element

### DIFF
--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -25,11 +25,11 @@ $this->Paginator->setTemplates([
 ?>
 <nav class="mt-3" aria-label="<?= __('Page navigation') ?>">
 	<ul class="pagination justify-content-center mb-2">
-		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escape' => false]) ?>
-		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escapeTitle' => false]) ?>
 		<?= $this->Paginator->numbers() ?>
-		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escape' => false]) ?>
-		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escapeTitle' => false]) ?>
 	</ul>
 	<p class="text-center text-muted small mb-0">
 		<?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>


### PR DESCRIPTION
Using `'escape' => false` on Paginator helpers also disables HTML escaping of attributes (URL, class, title attr), not just the title text. The narrower `'escapeTitle' => false` keeps attribute escaping on while still allowing the icon markup in the title.

Affects `templates/element/pagination.php` only.

| Before | After |
|---|---|
| `['escape' => false]` | `['escapeTitle' => false]` |

Defense-in-depth — no known exploit path because the call sites pass static strings, but keeping the strict default protects against future edits that wire dynamic values into pagination options.
