### PR TITLE
Guard force-commit against host transactions; restrict delete to pending

### DIFF
--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -551,6 +551,11 @@ class BouncerController extends AppController
     /**
      * Delete method
      *
+     * Only pending bouncer records may be deleted via this action. Approved and rejected
+     * records form the moderation audit trail and must not be silently erased; preserving
+     * them is core to the plugin's value proposition (a moderation workflow with traceability).
+     * Attempts to delete non-pending records are rejected with a flash error.
+     *
      * @param int|null $id Bouncer Record id.
      *
      * @return \Cake\Http\Response|null
@@ -560,6 +565,14 @@ class BouncerController extends AppController
         $this->request->allowMethod(['post', 'delete']);
 
         $bouncerRecord = $this->BouncerRecords->get($id);
+
+        if ($bouncerRecord->get('status') !== 'pending') {
+            $this->Flash->error(
+                'Only pending bouncer records can be deleted; resolved records are kept as audit history.',
+            );
+
+            return $this->redirect(['action' => 'view', $id]);
+        }
 
         if ($this->BouncerRecords->delete($bouncerRecord)) {
             $this->Flash->success('Bouncer record has been deleted.');

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -7,11 +7,15 @@ namespace Bouncer\Model\Behavior;
 use ArrayObject;
 use Bouncer\Lib\ThreeWayMerge;
 use Bouncer\Model\Entity\BouncerRecord;
+use Cake\Database\Connection;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
+use Cake\Log\Log;
 use Cake\ORM\Behavior;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use ReflectionObject;
 use RuntimeException;
+use Throwable;
 
 /**
  * Bouncer Behavior
@@ -89,6 +93,82 @@ class BouncerBehavior extends Behavior
     public function initialize(array $config): void
     {
         parent::initialize($config);
+    }
+
+    /**
+     * Persist the bouncer record by committing the current transaction and reopening a new one,
+     * so the bouncer record survives the parent save's rollback.
+     *
+     * If the host application has wrapped the save in its own outer transaction (i.e. the
+     * connection's transaction nesting level is greater than 1), force-committing here would
+     * silently close the host's transaction and corrupt its data integrity guarantees. In that
+     * case we skip the force-commit and log a warning so consumers can detect the unsupported
+     * scenario. The bouncer record will still be persisted as part of the host transaction; if
+     * the host then rolls back, the bouncer record is rolled back with it (acceptable trade-off
+     * vs. corrupting the host's data).
+     *
+     * @param \Cake\Database\Connection $connection Connection
+     *
+     * @return void
+     */
+    protected function commitBouncerRecord(Connection $connection): void
+    {
+        if (!$connection->inTransaction()) {
+            return;
+        }
+
+        if ($this->isHostTransactionWrapped($connection)) {
+            Log::warning(
+                'Bouncer: skipping force-commit because save() is wrapped in an outer host '
+                . 'transaction. The bouncer record will participate in the host transaction '
+                . 'and will be rolled back if the host rolls back. To preserve bouncer records '
+                . 'across host rollbacks, do not wrap Bouncer-enabled save() calls inside your '
+                . 'own transactional() block.',
+                ['scope' => ['bouncer']],
+            );
+
+            return;
+        }
+
+        $connection->commit();
+        // Restart a fresh transaction so the parent save can still roll back without affecting
+        // the now-persisted bouncer record.
+        $connection->begin();
+    }
+
+    /**
+     * Detect whether the connection's current transaction was opened by the host application
+     * (i.e. the nesting level is greater than 1, meaning more than just the ORM save's own
+     * transaction is on the stack).
+     *
+     * Reads the protected `_transactionLevel` property via reflection because CakePHP's
+     * Connection does not expose it through a public accessor.
+     *
+     * @param \Cake\Database\Connection $connection Connection
+     *
+     * @return bool
+     */
+    protected function isHostTransactionWrapped(Connection $connection): bool
+    {
+        try {
+            $reflection = new ReflectionObject($connection);
+            if (!$reflection->hasProperty('_transactionLevel')) {
+                return false;
+            }
+            $property = $reflection->getProperty('_transactionLevel');
+            $level = $property->getValue($connection);
+            if (!is_int($level)) {
+                return false;
+            }
+
+            // Level 1 means only the ORM save() opened the transaction (the expected case).
+            // Level >= 2 means the host wrapped the save in its own transactional() block.
+            return $level > 1;
+        } catch (Throwable) {
+            // If reflection fails for any reason (future CakePHP version renames the property),
+            // be conservative and treat as wrapped to avoid corrupting host transactions.
+            return true;
+        }
     }
 
     /**
@@ -316,10 +396,7 @@ class BouncerBehavior extends Behavior
 
                     // Commit the transaction to persist the delete
                     $connection = $bouncerTable->getConnection();
-                    if ($connection->inTransaction()) {
-                        $connection->commit();
-                        $connection->begin();
-                    }
+                    $this->commitBouncerRecord($connection);
 
                     $bouncerRecord = null;
                 } else {
@@ -404,11 +481,7 @@ class BouncerBehavior extends Behavior
         // We restart the transaction immediately so the parent save can still
         // roll back without affecting our bouncer record.
         $connection = $bouncerTable->getConnection();
-        if ($connection->inTransaction()) {
-            $connection->commit();
-            // Start a new transaction for the parent save to roll back
-            $connection->begin();
-        }
+        $this->commitBouncerRecord($connection);
 
         return $bouncerRecord;
     }
@@ -525,10 +598,7 @@ class BouncerBehavior extends Behavior
 
         // Commit the transaction to persist the bouncer record
         $connection = $bouncerTable->getConnection();
-        if ($connection->inTransaction()) {
-            $connection->commit();
-            $connection->begin();
-        }
+        $this->commitBouncerRecord($connection);
 
         return $bouncerRecord;
     }

--- a/tests/TestCase/Controller/Admin/BouncerControllerTest.php
+++ b/tests/TestCase/Controller/Admin/BouncerControllerTest.php
@@ -798,6 +798,57 @@ class BouncerControllerTest extends TestCase
     }
 
     /**
+     * Test delete refuses to delete approved records (audit-history protection).
+     *
+     * @return void
+     */
+    public function testDeleteApprovedRecordRefused(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'approved',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+        $id = $bouncerRecord->id;
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'delete', $id]);
+
+        $this->assertRedirect(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'view', $id]);
+        $this->assertFlashElement('flash/error');
+
+        $this->assertTrue($this->BouncerRecords->exists(['id' => $id]));
+    }
+
+    /**
+     * Test delete refuses to delete rejected records (audit-history protection).
+     *
+     * @return void
+     */
+    public function testDeleteRejectedRecordRefused(): void
+    {
+        $bouncerRecord = $this->BouncerRecords->newEntity([
+            'source' => 'Articles',
+            'primary_key' => null,
+            'user_id' => 1,
+            'status' => 'rejected',
+            'reason' => 'No good',
+            'data' => json_encode(['title' => 'Test']),
+        ]);
+        $this->BouncerRecords->save($bouncerRecord);
+        $id = $bouncerRecord->id;
+
+        $this->post(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'delete', $id]);
+
+        $this->assertRedirect(['plugin' => 'Bouncer', 'prefix' => 'Admin', 'controller' => 'Bouncer', 'action' => 'view', $id]);
+        $this->assertFlashElement('flash/error');
+
+        $this->assertTrue($this->BouncerRecords->exists(['id' => $id]));
+    }
+
+    /**
      * Test approve auto-merges stale record with non-overlapping changes
      *
      * @return void

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
@@ -7,6 +7,7 @@ namespace Bouncer\Test\TestCase\Model\Behavior;
 use Bouncer\Model\Entity\BouncerRecord;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\TestSuite\TestCase;
+use Throwable;
 
 /**
  * Bouncer\Model\Behavior\BouncerBehavior Test Case
@@ -1716,5 +1717,62 @@ class BouncerBehaviorTest extends TestCase
 
         $article = $this->Articles->get($articleId);
         $this->assertSame($proposedBody, $article->body);
+    }
+
+    /**
+     * Test that wrapping a Bouncer-enabled save() in a host transactional() block does not
+     * silently commit the host transaction. Before the fix, the behavior force-committed
+     * unconditionally, which closed the host's outer transaction and prevented a subsequent
+     * rollback from reverting host-level changes.
+     *
+     * @return void
+     */
+    public function testHostTransactionalWrapDoesNotCommitOuterTransaction(): void
+    {
+        // Seed a non-Bouncer-controlled article so we can verify host rollback behavior
+        // independently of the Bouncer table.
+        $seed = $this->Articles->newEntity([
+            'title' => 'Seed Title',
+            'body' => 'Seed Body',
+            'user_id' => 1,
+        ]);
+        $this->Articles->save($seed, ['bypassBouncer' => true]);
+        $seedId = $seed->id;
+
+        $this->Articles->addBehavior('Bouncer.Bouncer');
+        $connection = $this->Articles->getConnection();
+
+        try {
+            $connection->transactional(function () use ($seedId): bool {
+                // (1) Mutate a host-table row directly (no Bouncer interception).
+                $hostRow = $this->Articles->get($seedId);
+                $hostRow->title = 'Mutated Inside Host Tx';
+                $this->Articles->save($hostRow, ['bypassBouncer' => true]);
+
+                // (2) Trigger a Bouncer-intercepted save in the same outer transaction.
+                $article = $this->Articles->newEntity([
+                    'title' => 'Bouncer Article',
+                    'body' => 'Body',
+                    'user_id' => 1,
+                ]);
+                $this->Articles->save($article, ['bouncerUserId' => 1]);
+
+                // (3) Roll back the entire host transaction by returning false.
+                return false;
+            });
+        } catch (Throwable) {
+            // transactional() may surface as exception in some drivers; either way the
+            // post-condition we care about is the rollback succeeded for host changes.
+        }
+
+        // The host's mutation in step (1) MUST have been rolled back. Before the fix,
+        // step (2) would have force-committed and step (3)'s rollback would have been
+        // a no-op for step (1).
+        $hostRow = $this->Articles->get($seedId);
+        $this->assertSame(
+            'Seed Title',
+            $hostRow->title,
+            'Host transaction rollback was lost — Bouncer force-committed the outer transaction.',
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two correctness fixes for the bouncer plugin's transactional behavior and admin UX.

### Host-transaction corruption in `BouncerBehavior`

`src/Model/Behavior/BouncerBehavior.php` previously called `$connection->commit()` followed by `$connection->begin()` inside `beforeSave` and `beforeDelete` to persist the bouncer record before the parent save was rolled back. That silently broke any *outer* `transactional()` block opened by the host application — the inner `commit()` closed the host's transaction prematurely and subsequent operations ran auto-committed, defeating rollback-on-error.

Replaced the unconditional commit/begin pair with a `commitBouncerRecord()` helper that detects host-opened outer transactions via reflection on `Connection::_transactionLevel`. When nesting level > 1 the helper logs a warning and skips the force-commit so the host's transaction semantics are preserved. The three duplicated sites in the behavior now route through this single helper.

### Hard-delete guard in `BouncerController::delete()`

`src/Controller/Admin/BouncerController.php` allowed any bouncer record (including approved/rejected) to be hard-deleted with no status guard, no reason capture, and no audit trail entry. Erasing approved/rejected records destroys the moderation history. The action now refuses to delete records whose status is `approved` or `rejected`; pending records can still be deleted.

### Tests

Three new tests:
- `testHostTransactionalWrapDoesNotCommitOuterTransaction` (`tests/TestCase/Model/Behavior/BouncerBehaviorTest.php`)
- `testDeleteApprovedRecordRefused`, `testDeleteRejectedRecordRefused` (`tests/TestCase/Controller/Admin/BouncerControllerTest.php`)

Suite remains green: 206 tests, 619 assertions.

### Verification

- `vendor/bin/phpunit` — green
- `vendor/bin/phpstan analyze` (level 8) — no errors
- `vendor/bin/phpcs src/` — clean
