### PR TITLE
Add admin header clock, AuditStash v2 cross-link, debug-only Reset

### DIFF
--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -588,6 +588,8 @@ class BouncerController extends AppController
      * demo environments — refuses to run when `Configure::read('debug')`
      * is false so a misconfigured route can't wipe production data.
      *
+     * @throws \Cake\Http\Exception\ForbiddenException When debug is off.
+     *
      * @return \Cake\Http\Response|null
      */
     public function reset()

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -582,4 +582,26 @@ class BouncerController extends AppController
 
         return $this->redirect(['action' => 'index']);
     }
+
+    /**
+     * Truncate bouncer_records. Debug-only convenience for development /
+     * demo environments — refuses to run when `Configure::read('debug')`
+     * is false so a misconfigured route can't wipe production data.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function reset()
+    {
+        $this->request->allowMethod(['post']);
+        if (!Configure::read('debug')) {
+            throw new ForbiddenException('Bouncer reset is only available in debug mode.');
+        }
+
+        $connection = $this->BouncerRecords->getConnection();
+        $connection->execute('TRUNCATE TABLE ' . $connection->getDriver()->quoteIdentifier($this->BouncerRecords->getTable()));
+
+        $this->Flash->success(__d('bouncer', 'All bouncer records have been deleted.'));
+
+        return $this->redirect(['action' => 'index']);
+    }
 }

--- a/templates/element/Bouncer/sidebar.php
+++ b/templates/element/Bouncer/sidebar.php
@@ -60,4 +60,22 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
             </a>
         </nav>
     </div>
+
+    <?php if (\Cake\Core\Configure::read('debug')) { ?>
+    <div class="nav-section">
+        <div class="nav-section-title text-warning"><?= __d('bouncer', 'Debug') ?></div>
+        <nav class="nav flex-column">
+            <?= $this->Form->postLink(
+                $this->element('Bouncer.icon', ['name' => 'eraser', 'fallback' => 'fas fa-eraser']) . ' ' . __d('bouncer', 'Reset (truncate)'),
+                ['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'reset'],
+                [
+                    'class' => 'nav-link text-danger',
+                    'escapeTitle' => false,
+                    'confirm' => __d('bouncer', 'This wipes ALL bouncer records. Continue?'),
+                    'block' => true,
+                ],
+            ) ?>
+        </nav>
+    </div>
+    <?php } ?>
 </aside>

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -19,7 +19,7 @@ $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
 // AuditStash v2 (>=1.x with the dashboard PR) ships a top-level
 // AuditStashController. Older versions only have AuditLogsController.
 // Detect at runtime so the cross-link works on both.
-$auditStashEntryController = class_exists('\\AuditStash\\Controller\\Admin\\AuditStashController')
+$auditStashEntryController = class_exists('AuditStash\\Controller\\Admin\\AuditStashController')
     ? 'AuditStash'
     : 'AuditLogs';
 $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -16,6 +16,12 @@ $action = $this->getRequest()->getParam('action');
 $plugin = $this->getRequest()->getParam('plugin');
 $prefix = $this->getRequest()->getParam('prefix');
 $hasAuditStashPlugin = Plugin::isLoaded('AuditStash');
+// AuditStash v2 (>=1.x with the dashboard PR) ships a top-level
+// AuditStashController. Older versions only have AuditLogsController.
+// Detect at runtime so the cross-link works on both.
+$auditStashEntryController = class_exists('\\AuditStash\\Controller\\Admin\\AuditStashController')
+    ? 'AuditStash'
+    : 'AuditLogs';
 $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!DOCTYPE html>
@@ -297,8 +303,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             <i class="fas fa-shield-alt"></i>
             Bouncer Admin
         </a>
+        <span class="text-light small ms-auto me-3" title="<?= __d('bouncer', 'Server Time') ?>">
+            <i class="far fa-clock me-1"></i>
+            <?= date('Y-m-d H:i:s') ?>
+        </span>
         <?php if ($hasAuditStashPlugin) { ?>
-        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build(['plugin' => 'AuditStash', 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index']) ?>">
+        <a class="btn btn-outline-light btn-sm" href="<?= $this->Url->build(['plugin' => 'AuditStash', 'prefix' => $prefix, 'controller' => $auditStashEntryController, 'action' => 'index']) ?>">
             <i class="fas fa-clipboard-list me-1"></i>
             AuditStash
         </a>


### PR DESCRIPTION
Admin-header server-time clock, runtime class_exists() check on the AuditStash cross-link (links to AuditStashController::index when present, falls back to AuditLogsController::index otherwise), debug-only Reset (truncate) sidebar button with a new BouncerController::reset() action that refuses to run when debug is off.