### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/bouncer.pot
+++ b/resources/locales/bouncer.pot
@@ -1,0 +1,253 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 02:23+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "All bouncer records have been deleted."
+msgstr ""
+
+msgid "No changes detected"
+msgstr ""
+
+msgid "Before:"
+msgstr ""
+
+msgid "After:"
+msgstr ""
+
+msgid "New Record Data"
+msgstr ""
+
+msgid "Field"
+msgstr ""
+
+msgid "Value"
+msgstr ""
+
+msgid "Raw JSON Data"
+msgstr ""
+
+msgid "New Record"
+msgstr ""
+
+msgid "Edit to Record"
+msgstr ""
+
+msgid "User #{0}"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "Pending Approvals"
+msgstr ""
+
+msgid "Filter"
+msgstr ""
+
+msgid "Clear"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Review"
+msgstr ""
+
+msgid "Resolve Conflicts"
+msgstr ""
+
+msgid "Manual Resolution Required"
+msgstr ""
+
+msgid "Some fields have conflicting changes that could not be auto-merged. Please review and choose the correct value for each conflicting field."
+msgstr ""
+
+msgid "Auto-Merged Successfully"
+msgstr ""
+
+msgid "Some fields were automatically merged because the changes did not overlap."
+msgstr ""
+
+msgid "Record: {0} #{1}"
+msgstr ""
+
+msgid "Auto-Merged Fields"
+msgstr ""
+
+msgid "Original"
+msgstr ""
+
+msgid "Current"
+msgstr ""
+
+msgid "Proposed"
+msgstr ""
+
+msgid "Merged Result"
+msgstr ""
+
+msgid "Changes"
+msgstr ""
+
+msgid "AUTO-MERGED"
+msgstr ""
+
+msgid "Current:"
+msgstr ""
+
+msgid "Proposed:"
+msgstr ""
+
+msgid "Conflicting Fields - Manual Resolution Required"
+msgstr ""
+
+msgid "Choose Value"
+msgstr ""
+
+msgid "CONFLICT"
+msgstr ""
+
+msgid "Use Current"
+msgstr ""
+
+msgid "Use Proposed"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Save Merged Changes"
+msgstr ""
+
+msgid "Review Proposed Changes"
+msgstr ""
+
+msgid "Conflict Detected!"
+msgstr ""
+
+msgid "This record was modified after the draft was created, and some of the same fields were changed. Please review and merge the changes before approval."
+msgstr ""
+
+msgid "Note:"
+msgstr ""
+
+msgid "This record was modified after the draft was created, but the changes affect different fields. You can proceed with approval."
+msgstr ""
+
+msgid "View 3-Way Comparison"
+msgstr ""
+
+msgid "Bouncer Record Details"
+msgstr ""
+
+msgid "ID"
+msgstr ""
+
+msgid "Source"
+msgstr ""
+
+msgid "Record Type"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Submitted By"
+msgstr ""
+
+msgid "Submitted"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Reviewed By"
+msgstr ""
+
+msgid "Reviewed"
+msgstr ""
+
+msgid "User Note:"
+msgstr ""
+
+msgid "Reviewer Reason:"
+msgstr ""
+
+msgid "Proposed Changes"
+msgstr ""
+
+msgid "Approve Changes"
+msgstr ""
+
+msgid "Reject Changes"
+msgstr ""
+
+msgid "This proposal was rejected."
+msgstr ""
+
+msgid "Reopen for Review"
+msgstr ""
+
+msgid "Are you sure you want to reopen this proposal?"
+msgstr ""
+
+msgid "Back to List"
+msgstr ""
+
+msgid "Navigation"
+msgstr ""
+
+msgid "All Records"
+msgstr ""
+
+msgid "Status Filters"
+msgstr ""
+
+msgid "Pending"
+msgstr ""
+
+msgid "Approved"
+msgstr ""
+
+msgid "Rejected"
+msgstr ""
+
+msgid "All Statuses"
+msgstr ""
+
+msgid "Debug"
+msgstr ""
+
+msgid "Reset (truncate)"
+msgstr ""
+
+msgid "This wipes ALL bouncer records. Continue?"
+msgstr ""
+
+msgid "Page navigation"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Server Time"
+msgstr ""
+

--- a/src/View/Helper/BouncerHelper.php
+++ b/src/View/Helper/BouncerHelper.php
@@ -228,7 +228,7 @@ class BouncerHelper extends Helper
     public function diffInline(array $diffs): string
     {
         if (!$diffs) {
-            return '<p class="text-muted">' . __('No changes detected') . '</p>';
+            return '<p class="text-muted">' . __d('bouncer', 'No changes detected') . '</p>';
         }
 
         $output = '';
@@ -259,7 +259,7 @@ class BouncerHelper extends Helper
     public function diffSideBySide(array $diffs): string
     {
         if (!$diffs) {
-            return '<p class="text-muted">' . __('No changes detected') . '</p>';
+            return '<p class="text-muted">' . __d('bouncer', 'No changes detected') . '</p>';
         }
 
         $output = '';
@@ -292,11 +292,11 @@ class BouncerHelper extends Helper
     {
         $output = '<div class="row">';
         $output .= '<div class="col-md-6">';
-        $output .= '<span class="text-muted">' . __('Before:') . '</span>';
+        $output .= '<span class="text-muted">' . __d('bouncer', 'Before:') . '</span>';
         $output .= '<div class="p-2 bg-light border rounded"><del>' . h($baseStr) . '</del></div>';
         $output .= '</div>';
         $output .= '<div class="col-md-6">';
-        $output .= '<span class="text-muted">' . __('After:') . '</span>';
+        $output .= '<span class="text-muted">' . __d('bouncer', 'After:') . '</span>';
         $output .= '<div class="p-2 bg-warning border rounded"><ins><strong>' . h($proposedStr) . '</strong></ins></div>';
         $output .= '</div>';
         $output .= '</div>';
@@ -315,9 +315,9 @@ class BouncerHelper extends Helper
     {
         $data = $bouncerRecord->getData();
 
-        $output = '<h5>' . __('New Record Data') . '</h5>';
+        $output = '<h5>' . __d('bouncer', 'New Record Data') . '</h5>';
         $output .= '<table class="table table-bordered">';
-        $output .= '<thead><tr><th>' . __('Field') . '</th><th>' . __('Value') . '</th></tr></thead>';
+        $output .= '<thead><tr><th>' . __d('bouncer', 'Field') . '</th><th>' . __d('bouncer', 'Value') . '</th></tr></thead>';
         $output .= '<tbody>';
 
         foreach ($data as $field => $value) {
@@ -345,7 +345,7 @@ class BouncerHelper extends Helper
     public function rawJsonDetails(BouncerRecord $bouncerRecord): string
     {
         $output = '<details class="mt-3">';
-        $output .= '<summary><strong>' . __('Raw JSON Data') . '</strong></summary>';
+        $output .= '<summary><strong>' . __d('bouncer', 'Raw JSON Data') . '</strong></summary>';
         $output .= '<pre class="bg-light p-3 mt-2"><code>';
         $output .= h(json_encode($bouncerRecord->getData(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         $output .= '</code></pre></details>';
@@ -383,12 +383,12 @@ class BouncerHelper extends Helper
     public function recordTypeBadge(BouncerRecord $bouncerRecord): string
     {
         if ($bouncerRecord->isNewRecordProposal()) {
-            return '<span class="badge bg-success">' . __('New Record') . '</span>';
+            return '<span class="badge bg-success">' . __d('bouncer', 'New Record') . '</span>';
         }
 
         $recordLink = $this->formatRecord($bouncerRecord->source, $bouncerRecord->primary_key);
 
-        return '<span class="badge bg-info">' . __('Edit to Record') . '</span> ' . $recordLink;
+        return '<span class="badge bg-info">' . __d('bouncer', 'Edit to Record') . '</span> ' . $recordLink;
     }
 
     /**
@@ -566,7 +566,7 @@ JS;
             return '<em class="text-muted">N/A</em>';
         }
 
-        $label = $displayName ?: __('User #{0}', $userId);
+        $label = $displayName ?: __d('bouncer', 'User #{0}', $userId);
 
         $linkConfig = Configure::read('Bouncer.linkUser');
         if ($linkConfig) {
@@ -600,7 +600,7 @@ JS;
     public function formatRecord(string $source, string|int|null $primaryKey): string
     {
         if ($primaryKey === null) {
-            return '<span class="badge bg-success">' . __('New') . '</span>';
+            return '<span class="badge bg-success">' . __d('bouncer', 'New') . '</span>';
         }
 
         // Extract plugin and table name from source

--- a/templates/Admin/Bouncer/index.php
+++ b/templates/Admin/Bouncer/index.php
@@ -9,7 +9,7 @@
  */
 ?>
 <div class="bouncer index content">
-    <h1><?= __('Pending Approvals') ?></h1>
+    <h1><?= __d('bouncer', 'Pending Approvals') ?></h1>
 
     <div class="filters card mb-3">
         <div class="card-body">
@@ -46,9 +46,9 @@
                     ]) ?>
                 </div>
                 <div class="col-md-3 d-flex align-items-end">
-                    <?= $this->Form->button(__('Filter'), ['class' => 'btn btn-primary']) ?>
+                    <?= $this->Form->button(__d('bouncer', 'Filter'), ['class' => 'btn btn-primary']) ?>
                     <?php if ($this->request->getQueryParams()) { ?>
-                        <?= $this->Html->link(__('Clear'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+                        <?= $this->Html->link(__d('bouncer', 'Clear'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
                     <?php } ?>
                 </div>
             </div>
@@ -66,7 +66,7 @@
                     <th><?= $this->Paginator->sort('user_id', 'Submitted By') ?></th>
                     <th><?= $this->Paginator->sort('status') ?></th>
                     <th><?= $this->Paginator->sort('created') ?></th>
-                    <th class="actions"><?= __('Actions') ?></th>
+                    <th class="actions"><?= __d('bouncer', 'Actions') ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -100,7 +100,7 @@
                         </td>
                         <td><?= h($bouncerRecord->created) ?></td>
                         <td class="actions">
-                            <?= $this->Html->link(__('Review'), ['action' => 'view', $bouncerRecord->id], ['class' => 'btn btn-sm btn-' . ($bouncerRecord->isPending() ? 'primary' : 'secondary')]) ?>
+                            <?= $this->Html->link(__d('bouncer', 'Review'), ['action' => 'view', $bouncerRecord->id], ['class' => 'btn btn-sm btn-' . ($bouncerRecord->isPending() ? 'primary' : 'secondary')]) ?>
                         </td>
                     </tr>
                 <?php } ?>

--- a/templates/Admin/Bouncer/resolve.php
+++ b/templates/Admin/Bouncer/resolve.php
@@ -28,25 +28,25 @@ $hasAutoMerged = !empty($conflict['autoMerged']);
 $hasConflicts = !empty($conflict['conflicts']);
 ?>
 <div class="bouncer resolve content">
-    <h1><?= __('Resolve Conflicts') ?></h1>
+    <h1><?= __d('bouncer', 'Resolve Conflicts') ?></h1>
 
     <?php if ($hasConflicts) { ?>
         <div class="alert alert-danger">
-            <strong><?= __('Manual Resolution Required') ?></strong>
-            <?= __('Some fields have conflicting changes that could not be auto-merged. Please review and choose the correct value for each conflicting field.') ?>
+            <strong><?= __d('bouncer', 'Manual Resolution Required') ?></strong>
+            <?= __d('bouncer', 'Some fields have conflicting changes that could not be auto-merged. Please review and choose the correct value for each conflicting field.') ?>
         </div>
     <?php } ?>
 
     <?php if ($hasAutoMerged) { ?>
         <div class="alert alert-success">
-            <strong><?= __('Auto-Merged Successfully') ?></strong>
-            <?= __('Some fields were automatically merged because the changes did not overlap.') ?>
+            <strong><?= __d('bouncer', 'Auto-Merged Successfully') ?></strong>
+            <?= __d('bouncer', 'Some fields were automatically merged because the changes did not overlap.') ?>
         </div>
     <?php } ?>
 
     <div class="card mb-3">
         <div class="card-header">
-            <strong><?= __('Record: {0} #{1}', h($bouncerRecord->source), $bouncerRecord->primary_key) ?></strong>
+            <strong><?= __d('bouncer', 'Record: {0} #{1}', h($bouncerRecord->source), $bouncerRecord->primary_key) ?></strong>
         </div>
     </div>
 
@@ -55,19 +55,19 @@ $hasConflicts = !empty($conflict['conflicts']);
     <?php if ($hasAutoMerged) { ?>
         <div class="card mb-3">
             <div class="card-header bg-success text-white">
-                <strong><?= __('Auto-Merged Fields') ?></strong>
+                <strong><?= __d('bouncer', 'Auto-Merged Fields') ?></strong>
             </div>
             <div class="card-body">
                 <div class="table-responsive">
                     <table class="table table-bordered table-sm">
                         <thead class="table-light">
                             <tr>
-                                <th class="bouncer-col-w-12"><?= __('Field') ?></th>
-                                <th class="bouncer-col-w-18"><?= __('Original') ?></th>
-                                <th class="bouncer-col-w-18"><?= __('Current') ?></th>
-                                <th class="bouncer-col-w-18"><?= __('Proposed') ?></th>
-                                <th class="bouncer-col-w-18"><?= __('Merged Result') ?></th>
-                                <th class="bouncer-col-w-16"><?= __('Changes') ?></th>
+                                <th class="bouncer-col-w-12"><?= __d('bouncer', 'Field') ?></th>
+                                <th class="bouncer-col-w-18"><?= __d('bouncer', 'Original') ?></th>
+                                <th class="bouncer-col-w-18"><?= __d('bouncer', 'Current') ?></th>
+                                <th class="bouncer-col-w-18"><?= __d('bouncer', 'Proposed') ?></th>
+                                <th class="bouncer-col-w-18"><?= __d('bouncer', 'Merged Result') ?></th>
+                                <th class="bouncer-col-w-16"><?= __d('bouncer', 'Changes') ?></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -75,7 +75,7 @@ $hasConflicts = !empty($conflict['conflicts']);
                                 <tr class="table-success">
                                     <td>
                                         <strong><?= h($field) ?></strong>
-                                        <br><span class="badge bg-success"><?= __('AUTO-MERGED') ?></span>
+                                        <br><span class="badge bg-success"><?= __d('bouncer', 'AUTO-MERGED') ?></span>
                                     </td>
                                     <td class="text-muted">
                                         <div class="small text-break"><?= $formatValue($data['original']) ?></div>
@@ -93,7 +93,7 @@ $hasConflicts = !empty($conflict['conflicts']);
                                     <td class="small">
                                         <?php if ($data['currentChanges']) { ?>
                                             <div class="text-info mb-1">
-                                                <strong><?= __('Current:') ?></strong>
+                                                <strong><?= __d('bouncer', 'Current:') ?></strong>
                                                 <?php foreach ($data['currentChanges'] as $change) { ?>
                                                     <div><?= h($change) ?></div>
                                                 <?php } ?>
@@ -101,7 +101,7 @@ $hasConflicts = !empty($conflict['conflicts']);
                                         <?php } ?>
                                         <?php if ($data['proposedChanges']) { ?>
                                             <div class="text-primary">
-                                                <strong><?= __('Proposed:') ?></strong>
+                                                <strong><?= __d('bouncer', 'Proposed:') ?></strong>
                                                 <?php foreach ($data['proposedChanges'] as $change) { ?>
                                                     <div><?= h($change) ?></div>
                                                 <?php } ?>
@@ -120,18 +120,18 @@ $hasConflicts = !empty($conflict['conflicts']);
     <?php if ($hasConflicts) { ?>
         <div class="card mb-3">
             <div class="card-header bg-danger text-white">
-                <strong><?= __('Conflicting Fields - Manual Resolution Required') ?></strong>
+                <strong><?= __d('bouncer', 'Conflicting Fields - Manual Resolution Required') ?></strong>
             </div>
             <div class="card-body">
                 <div class="table-responsive">
                     <table class="table table-bordered table-sm">
                         <thead class="table-light">
                             <tr>
-                                <th class="bouncer-col-w-15"><?= __('Field') ?></th>
-                                <th class="bouncer-col-w-20"><?= __('Original') ?></th>
-                                <th class="bouncer-col-w-20"><?= __('Current') ?></th>
-                                <th class="bouncer-col-w-20"><?= __('Proposed') ?></th>
-                                <th class="bouncer-col-w-25"><?= __('Choose Value') ?></th>
+                                <th class="bouncer-col-w-15"><?= __d('bouncer', 'Field') ?></th>
+                                <th class="bouncer-col-w-20"><?= __d('bouncer', 'Original') ?></th>
+                                <th class="bouncer-col-w-20"><?= __d('bouncer', 'Current') ?></th>
+                                <th class="bouncer-col-w-20"><?= __d('bouncer', 'Proposed') ?></th>
+                                <th class="bouncer-col-w-25"><?= __d('bouncer', 'Choose Value') ?></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -142,7 +142,7 @@ $hasConflicts = !empty($conflict['conflicts']);
                                 <tr class="table-danger">
                                     <td>
                                         <strong><?= h($field) ?></strong>
-                                        <br><span class="badge bg-danger"><?= __('CONFLICT') ?></span>
+                                        <br><span class="badge bg-danger"><?= __d('bouncer', 'CONFLICT') ?></span>
                                     </td>
                                     <td class="text-muted">
                                         <div class="small text-break"><?= $formatValue($data['original']) ?></div>
@@ -166,12 +166,12 @@ $hasConflicts = !empty($conflict['conflicts']);
                                             <button type="button" class="btn btn-outline-info use-value"
                                                     data-field="<?= h($field) ?>"
                                                     data-value="<?= h($data['current']) ?>">
-                                                <?= __('Use Current') ?>
+                                                <?= __d('bouncer', 'Use Current') ?>
                                             </button>
                                             <button type="button" class="btn btn-outline-primary use-value"
                                                     data-field="<?= h($field) ?>"
                                                     data-value="<?= h($data['proposed']) ?>">
-                                                <?= __('Use Proposed') ?>
+                                                <?= __d('bouncer', 'Use Proposed') ?>
                                             </button>
                                         </div>
                                     </td>
@@ -203,8 +203,8 @@ $hasConflicts = !empty($conflict['conflicts']);
     <div class="card">
         <div class="card-body">
             <div class="d-flex justify-content-between">
-                <?= $this->Html->link(__('Cancel'), ['action' => 'view', $bouncerRecord->id], ['class' => 'btn btn-secondary']) ?>
-                <?= $this->Form->button(__('Save Merged Changes'), ['class' => 'btn btn-primary']) ?>
+                <?= $this->Html->link(__d('bouncer', 'Cancel'), ['action' => 'view', $bouncerRecord->id], ['class' => 'btn btn-secondary']) ?>
+                <?= $this->Form->button(__d('bouncer', 'Save Merged Changes'), ['class' => 'btn btn-primary']) ?>
             </div>
         </div>
     </div>

--- a/templates/Admin/Bouncer/view.php
+++ b/templates/Admin/Bouncer/view.php
@@ -10,15 +10,15 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
 ?>
 <?= $this->Bouncer->diffStyles() ?>
 <div class="bouncer view content">
-    <h1><?= __('Review Proposed Changes') ?></h1>
+    <h1><?= __d('bouncer', 'Review Proposed Changes') ?></h1>
 
     <?php if (!empty($conflict) && $conflict['hasConflicts']) { ?>
         <div class="alert alert-warning">
-            <strong><?= __('Conflict Detected!') ?></strong>
-            <?= __('This record was modified after the draft was created, and some of the same fields were changed. Please review and merge the changes before approval.') ?>
+            <strong><?= __d('bouncer', 'Conflict Detected!') ?></strong>
+            <?= __d('bouncer', 'This record was modified after the draft was created, and some of the same fields were changed. Please review and merge the changes before approval.') ?>
             <div class="mt-2">
                 <?= $this->Html->link(
-                    __('Resolve Conflicts'),
+                    __d('bouncer', 'Resolve Conflicts'),
                     ['action' => 'resolve', $bouncerRecord->id],
                     ['class' => 'btn btn-warning btn-sm']
                 ) ?>
@@ -26,11 +26,11 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
         </div>
     <?php } elseif (!empty($conflict)) { ?>
         <div class="alert alert-info">
-            <strong><?= __('Note:') ?></strong>
-            <?= __('This record was modified after the draft was created, but the changes affect different fields. You can proceed with approval.') ?>
+            <strong><?= __d('bouncer', 'Note:') ?></strong>
+            <?= __d('bouncer', 'This record was modified after the draft was created, but the changes affect different fields. You can proceed with approval.') ?>
             <div class="mt-2">
                 <?= $this->Html->link(
-                    __('View 3-Way Comparison'),
+                    __d('bouncer', 'View 3-Way Comparison'),
                     ['action' => 'resolve', $bouncerRecord->id],
                     ['class' => 'btn btn-info btn-sm']
                 ) ?>
@@ -40,26 +40,26 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
 
     <div class="card mb-3">
         <div class="card-header">
-            <strong><?= __('Bouncer Record Details') ?></strong>
+            <strong><?= __d('bouncer', 'Bouncer Record Details') ?></strong>
         </div>
         <div class="card-body">
             <div class="row">
                 <div class="col-md-6">
                     <table class="table table-sm">
                         <tr>
-                            <th><?= __('ID') ?></th>
+                            <th><?= __d('bouncer', 'ID') ?></th>
                             <td><?= $this->Number->format($bouncerRecord->id) ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('Source') ?></th>
+                            <th><?= __d('bouncer', 'Source') ?></th>
                             <td><code><?= h($bouncerRecord->source) ?></code></td>
                         </tr>
                         <tr>
-                            <th><?= __('Record Type') ?></th>
+                            <th><?= __d('bouncer', 'Record Type') ?></th>
                             <td><?= $this->Bouncer->recordTypeBadge($bouncerRecord) ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('Status') ?></th>
+                            <th><?= __d('bouncer', 'Status') ?></th>
                             <td><?= $this->Bouncer->statusBadge($bouncerRecord->status) ?></td>
                         </tr>
                     </table>
@@ -67,24 +67,24 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
                 <div class="col-md-6">
                     <table class="table table-sm">
                         <tr>
-                            <th><?= __('Submitted By') ?></th>
+                            <th><?= __d('bouncer', 'Submitted By') ?></th>
                             <td><?= $this->Bouncer->formatUser($bouncerRecord->user_id, $bouncerRecord->user_display) ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('Submitted') ?></th>
+                            <th><?= __d('bouncer', 'Submitted') ?></th>
                             <td><?= h($bouncerRecord->created) ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('Modified') ?></th>
+                            <th><?= __d('bouncer', 'Modified') ?></th>
                             <td><?= h($bouncerRecord->modified) ?></td>
                         </tr>
                         <?php if ($bouncerRecord->reviewer_id) { ?>
                             <tr>
-                                <th><?= __('Reviewed By') ?></th>
+                                <th><?= __d('bouncer', 'Reviewed By') ?></th>
                                 <td><?= $this->Bouncer->formatUser($bouncerRecord->reviewer_id, $bouncerRecord->reviewer_display) ?></td>
                             </tr>
                             <tr>
-                                <th><?= __('Reviewed') ?></th>
+                                <th><?= __d('bouncer', 'Reviewed') ?></th>
                                 <td><?= h($bouncerRecord->reviewed) ?></td>
                             </tr>
                         <?php } ?>
@@ -94,13 +94,13 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
 
             <?php if ($bouncerRecord->note) { ?>
                 <div class="alert alert-secondary mt-3">
-                    <strong><?= __('User Note:') ?></strong> <?= h($bouncerRecord->note) ?>
+                    <strong><?= __d('bouncer', 'User Note:') ?></strong> <?= h($bouncerRecord->note) ?>
                 </div>
             <?php } ?>
 
             <?php if ($bouncerRecord->reason) { ?>
                 <div class="alert alert-info mt-3">
-                    <strong><?= __('Reviewer Reason:') ?></strong> <?= h($bouncerRecord->reason) ?>
+                    <strong><?= __d('bouncer', 'Reviewer Reason:') ?></strong> <?= h($bouncerRecord->reason) ?>
                 </div>
             <?php } ?>
         </div>
@@ -108,7 +108,7 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
 
     <div class="card mb-3">
         <div class="card-header d-flex justify-content-between align-items-center">
-            <strong><?= __('Proposed Changes') ?></strong>
+            <strong><?= __d('bouncer', 'Proposed Changes') ?></strong>
             <?php if ($bouncerRecord->isEditProposal() && $currentRecord && $diffs) { ?>
                 <?= $this->Bouncer->diffToggleButtons() ?>
             <?php } ?>
@@ -132,7 +132,7 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
     <?php if ($bouncerRecord->isPending()) { ?>
         <div class="card">
             <div class="card-header">
-                <strong><?= __('Actions') ?></strong>
+                <strong><?= __d('bouncer', 'Actions') ?></strong>
             </div>
             <div class="card-body">
                 <div class="row">
@@ -143,7 +143,7 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
                             'type' => 'textarea',
                             'rows' => 2,
                         ]) ?>
-                        <?= $this->Form->button(__('Approve Changes'), ['class' => 'btn btn-success']) ?>
+                        <?= $this->Form->button(__d('bouncer', 'Approve Changes'), ['class' => 'btn btn-success']) ?>
                         <?= $this->Form->end() ?>
                     </div>
                     <div class="col-md-6">
@@ -154,7 +154,7 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
                             'rows' => 2,
                             'required' => true,
                         ]) ?>
-                        <?= $this->Form->button(__('Reject Changes'), ['class' => 'btn btn-danger']) ?>
+                        <?= $this->Form->button(__d('bouncer', 'Reject Changes'), ['class' => 'btn btn-danger']) ?>
                         <?= $this->Form->end() ?>
                     </div>
                 </div>
@@ -163,18 +163,18 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
     <?php } elseif ($bouncerRecord->status === 'rejected') { ?>
         <div class="card">
             <div class="card-header">
-                <strong><?= __('Actions') ?></strong>
+                <strong><?= __d('bouncer', 'Actions') ?></strong>
             </div>
             <div class="card-body">
-                <p class="text-muted"><?= __('This proposal was rejected.') ?></p>
+                <p class="text-muted"><?= __d('bouncer', 'This proposal was rejected.') ?></p>
                 <?= $this->Form->postButton(
-                    __('Reopen for Review'),
+                    __d('bouncer', 'Reopen for Review'),
                     ['action' => 'reopen', $bouncerRecord->id],
                     [
                         'class' => 'btn btn-warning',
                         'form' => [
                             'class' => 'd-inline',
-                            'data-confirm-message' => __('Are you sure you want to reopen this proposal?'),
+                            'data-confirm-message' => __d('bouncer', 'Are you sure you want to reopen this proposal?'),
                         ],
                     ]
                 ) ?>
@@ -183,7 +183,7 @@ $diffs = $this->Bouncer->calculateDiffs($bouncerRecord, $currentRecord);
     <?php } ?>
 
     <div class="mt-3">
-        <?= $this->Html->link(__('Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+        <?= $this->Html->link(__d('bouncer', 'Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
     </div>
 </div>
 

--- a/templates/element/Bouncer/mobile_nav.php
+++ b/templates/element/Bouncer/mobile_nav.php
@@ -34,39 +34,39 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
     <div class="offcanvas-body">
         <!-- Navigation -->
         <div class="mb-4">
-            <div class="text-white-50 small text-uppercase mb-2"><?= __('Navigation') ?></div>
+            <div class="text-white-50 small text-uppercase mb-2"><?= __d('bouncer', 'Navigation') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50 <?= $isActive('Bouncer', ['index']) ? 'text-white fw-bold' : '' ?>"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
                     <i class="fas fa-list me-2"></i>
-                    <?= __('All Records') ?>
+                    <?= __d('bouncer', 'All Records') ?>
                 </a>
             </nav>
         </div>
 
         <!-- Status Filters -->
         <div class="mb-4">
-            <div class="text-white-50 small text-uppercase mb-2"><?= __('Status Filters') ?></div>
+            <div class="text-white-50 small text-uppercase mb-2"><?= __d('bouncer', 'Status Filters') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
                     <i class="fas fa-clock me-2"></i>
-                    <?= __('Pending') ?>
+                    <?= __d('bouncer', 'Pending') ?>
                 </a>
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
                     <i class="fas fa-check-circle me-2"></i>
-                    <?= __('Approved') ?>
+                    <?= __d('bouncer', 'Approved') ?>
                 </a>
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
                     <i class="fas fa-times-circle me-2"></i>
-                    <?= __('Rejected') ?>
+                    <?= __d('bouncer', 'Rejected') ?>
                 </a>
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
                     <i class="fas fa-globe me-2"></i>
-                    <?= __('All Statuses') ?>
+                    <?= __d('bouncer', 'All Statuses') ?>
                 </a>
             </nav>
         </div>

--- a/templates/element/Bouncer/sidebar.php
+++ b/templates/element/Bouncer/sidebar.php
@@ -24,39 +24,39 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
 <aside class="bouncer-sidebar d-none d-lg-block">
     <!-- Navigation -->
     <div class="nav-section">
-        <div class="nav-section-title"><?= __('Navigation') ?></div>
+        <div class="nav-section-title"><?= __d('bouncer', 'Navigation') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link <?= $isActive('Bouncer', ['index']) ?>"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'list', 'fallback' => 'fas fa-list']) ?>
-                <?= __('All Records') ?>
+                <?= __d('bouncer', 'All Records') ?>
             </a>
         </nav>
     </div>
 
     <!-- Quick Filters -->
     <div class="nav-section">
-        <div class="nav-section-title"><?= __('Status Filters') ?></div>
+        <div class="nav-section-title"><?= __d('bouncer', 'Status Filters') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'pending']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'clock', 'fallback' => 'fas fa-clock']) ?>
-                <?= __('Pending') ?>
+                <?= __d('bouncer', 'Pending') ?>
             </a>
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'approved']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'check-circle', 'fallback' => 'fas fa-check-circle']) ?>
-                <?= __('Approved') ?>
+                <?= __d('bouncer', 'Approved') ?>
             </a>
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'rejected']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'times-circle', 'fallback' => 'fas fa-times-circle']) ?>
-                <?= __('Rejected') ?>
+                <?= __d('bouncer', 'Rejected') ?>
             </a>
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index', '?' => ['status' => 'all']]) ?>">
                 <?= $this->element('Bouncer.icon', ['name' => 'globe', 'fallback' => 'fas fa-globe']) ?>
-                <?= __('All Statuses') ?>
+                <?= __d('bouncer', 'All Statuses') ?>
             </a>
         </nav>
     </div>

--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -23,7 +23,7 @@ $this->Paginator->setTemplates([
 	'current' => '<li class="page-item active"><span class="page-link">{{text}}</span></li>',
 ]);
 ?>
-<nav class="mt-3" aria-label="<?= __('Page navigation') ?>">
+<nav class="mt-3" aria-label="<?= __d('bouncer', 'Page navigation') ?>">
 	<ul class="pagination justify-content-center mb-2">
 		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escape' => false]) ?>
 		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escape' => false]) ?>
@@ -32,6 +32,6 @@ $this->Paginator->setTemplates([
 		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escape' => false]) ?>
 	</ul>
 	<p class="text-center text-muted small mb-0">
-		<?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>
+		<?= $this->Paginator->counter(__d('bouncer', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>
 	</p>
 </nav>

--- a/templates/element/yes_no.php
+++ b/templates/element/yes_no.php
@@ -13,8 +13,8 @@
 $value = $value ?? false;
 $options = $options ?? [];
 
-$yesLabel = $options['yesLabel'] ?? __('Yes');
-$noLabel = $options['noLabel'] ?? __('No');
+$yesLabel = $options['yesLabel'] ?? __d('bouncer', 'Yes');
+$noLabel = $options['noLabel'] ?? __d('bouncer', 'No');
 
 // Try Templating plugin's helper
 if ($this->helpers()->has('Templating')) {


### PR DESCRIPTION
## Summary

- Convert 89 `__()` calls across `src/` and `templates/` to `__d('bouncer', ...)`. The 5 pre-existing `__d('bouncer', ...)` calls already pointed at the right domain — the rest of the plugin now matches.
- Add `resources/locales/bouncer.pot` (80 unique msgids) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 206 / 206
- phpstan: no errors
- phpcs: clean