### PR TITLE
Add configurable Back-to-App link to admin header

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -20,6 +20,29 @@ return [
         'adminLayout' => null,
 
         /**
+         * Back-to-App link in the admin header
+         *
+         * Optional. When set, an outline "Back to App" button appears in the
+         * admin header between the brand and the AuditStash cross-link/clock
+         * — gives admins a one-click way out of the plugin-isolated layout
+         * back to the host application's admin home (or wherever you point
+         * it).
+         *
+         * Accepts anything `\Cake\Routing\Router::url()` accepts: a Cake URL
+         * array, a path string, or a full URL. Use `'plugin' => false` to
+         * anchor the URL builder to the host app rather than this plugin.
+         *
+         * Defaults to null (button hidden).
+         */
+        // 'adminBackUrl' => ['plugin' => false, 'prefix' => 'Admin', 'controller' => 'Overview', 'action' => 'index'],
+
+        /**
+         * Optional override for the Back-to-App button's text. Defaults to
+         * "Back to App" (translated through the `bouncer` domain).
+         */
+        // 'adminBackLabel' => 'Back to admin',
+
+        /**
          * Standalone Mode
          *
          * When enabled, the admin interface operates independently without

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -78,6 +78,33 @@ Controls the layout used by the admin UI.
 | `false` | Disable the plugin layout entirely — render inside the app's default layout. |
 | `string` | Use a named layout, e.g. `'Admin.default'` or `'MyTheme.admin'`, to integrate with an existing admin theme. |
 
+### `Bouncer.adminBackUrl` / `Bouncer.adminBackLabel`
+
+Optional. When set, an outline "Back to App" button appears in the admin
+header, between the brand and the AuditStash cross-link/clock — gives
+admins a one-click escape from the plugin-isolated layout back to the
+host application.
+
+`adminBackUrl` accepts anything `Router::url()` accepts: a Cake URL array,
+a path string, or a full URL. Use `'plugin' => false` to anchor the URL
+builder to the host app rather than the plugin's namespace.
+`adminBackLabel` is optional and defaults to `"Back to App"` (translated
+through the `bouncer` domain).
+
+```php
+'Bouncer' => [
+    'adminBackUrl' => [
+        'plugin' => false,
+        'prefix' => 'Admin',
+        'controller' => 'Overview',
+        'action' => 'index',
+    ],
+    'adminBackLabel' => __('Back to admin'), // optional
+],
+```
+
+When unset (the default), the button is hidden — the header looks unchanged.
+
 ### `Bouncer.standalone`
 
 When `true`, the admin controller does not extend host `AppController`'s

--- a/templates/layout/bouncer.php
+++ b/templates/layout/bouncer.php
@@ -303,13 +303,24 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             <i class="fas fa-shield-alt"></i>
             Bouncer Admin
         </a>
+        <?php
+        $adminBackUrl = Configure::read('Bouncer.adminBackUrl');
+        $hasAdminBack = $adminBackUrl !== null && $adminBackUrl !== '';
+        $adminBackLabel = (string)Configure::read('Bouncer.adminBackLabel', __d('bouncer', 'Back to App'));
+        ?>
+        <?php if ($hasAdminBack) { ?>
+        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build($adminBackUrl) ?>">
+            <i class="fas fa-arrow-left me-1"></i>
+            <?= h($adminBackLabel) ?>
+        </a>
+        <?php } ?>
         <?php if ($hasAuditStashPlugin) { ?>
-        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build(['plugin' => 'AuditStash', 'prefix' => $prefix, 'controller' => $auditStashEntryController, 'action' => 'index']) ?>">
+        <a class="btn btn-outline-light btn-sm <?= $hasAdminBack ? 'ms-2' : 'ms-auto' ?>" href="<?= $this->Url->build(['plugin' => 'AuditStash', 'prefix' => $prefix, 'controller' => $auditStashEntryController, 'action' => 'index']) ?>">
             <i class="fas fa-clipboard-list me-1"></i>
             AuditStash
         </a>
         <?php } ?>
-        <span class="text-light small <?= $hasAuditStashPlugin ? 'ms-3' : 'ms-auto' ?>" title="<?= __d('bouncer', 'Server Time') ?>">
+        <span class="text-light small <?= ($hasAdminBack || $hasAuditStashPlugin) ? 'ms-3' : 'ms-auto' ?>" title="<?= __d('bouncer', 'Server Time') ?>">
             <i class="far fa-clock me-1"></i>
             <?= date('Y-m-d H:i:s') ?>
         </span>


### PR DESCRIPTION
Configurable Back-to-App link in the admin header. Reads `<Plugin>.adminBackUrl` (any URL — string, array, anything `$this->Url->build()` accepts). Optional `<Plugin>.adminBackLabel` overrides the default "Back to App" text. Hidden by default — set the URL to opt in.

Same shape across cakephp-audit-stash, cakephp-bouncer, and cakephp-databaselog so hosts loading multiple plugins set them with consistent config.