### PR TITLE
Make transaction-depth detection rename-safe; extend pending-draft index

### DIFF
--- a/config/Migrations/20260512000000_AddPendingDraftLookupIndex.php
+++ b/config/Migrations/20260512000000_AddPendingDraftLookupIndex.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+/**
+ * Adds a composite index covering the per-user pending-draft lookup performed
+ * by `BouncerRecordsTable::findPendingForRecord($source, $primaryKey, $userId)`
+ * on every save against a Bouncer-enabled table.
+ *
+ * The original migration shipped `(source, primary_key, status)` which works
+ * well for the global lookup but leaves `user_id` as a residual filter; adding
+ * it to the composite makes the per-user case index-only. The standalone
+ * `(user_id)` index from the original migration is preserved — it still serves
+ * the admin-side "show all pending drafts by user X" queries.
+ */
+class AddPendingDraftLookupIndex extends BaseMigration
+{
+    public function up(): void
+    {
+        $this->table('bouncer_records')
+            ->addIndex(
+                ['source', 'primary_key', 'status', 'user_id'],
+                ['name' => 'bouncer_pending_lookup'],
+            )
+            ->update();
+    }
+
+    public function down(): void
+    {
+        $this->table('bouncer_records')
+            ->removeIndexByName('bouncer_pending_lookup')
+            ->update();
+    }
+}

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -153,12 +153,28 @@ class BouncerBehavior extends Behavior
     }
 
     /**
+     * Property names CakePHP's `Connection` has used (and may use) for the
+     * current transaction-nesting depth. Probed in order so we keep working
+     * if/when cake-core renames `_transactionLevel` (the underscore prefix is
+     * a legacy 4.x convention that the project is gradually shedding).
+     *
+     * @var list<string>
+     */
+    protected const TRANSACTION_LEVEL_CANDIDATES = ['_transactionLevel', 'transactionLevel'];
+
+    /**
      * Detect whether the connection's current transaction was opened by the host application
      * (i.e. the nesting level is greater than 1, meaning more than just the ORM save's own
      * transaction is on the stack).
      *
-     * Reads the protected `_transactionLevel` property via reflection because CakePHP's
-     * Connection does not expose it through a public accessor.
+     * Reads the protected transaction-level property via reflection because CakePHP's
+     * Connection does not expose it through a public accessor. Tries multiple candidate
+     * property names (see {@see self::TRANSACTION_LEVEL_CANDIDATES}) so a rename in a
+     * future cake-core release does not silently flip the behavior into the unsafe branch.
+     * If introspection genuinely fails, the method returns `true` — that's the safe
+     * direction (skip force-commit, let the bouncer record participate in the host
+     * transaction) rather than the dangerous direction (force-commit and corrupt
+     * the host's transaction).
      *
      * @param \Cake\Database\Connection $connection Connection
      *
@@ -166,25 +182,40 @@ class BouncerBehavior extends Behavior
      */
     protected function isHostTransactionWrapped(Connection $connection): bool
     {
-        try {
-            $reflection = new ReflectionObject($connection);
-            if (!$reflection->hasProperty('_transactionLevel')) {
-                return false;
+        $reflection = new ReflectionObject($connection);
+        foreach (static::TRANSACTION_LEVEL_CANDIDATES as $candidate) {
+            if (!$reflection->hasProperty($candidate)) {
+                continue;
             }
-            $property = $reflection->getProperty('_transactionLevel');
-            $level = $property->getValue($connection);
+            try {
+                $level = $reflection->getProperty($candidate)->getValue($connection);
+            } catch (Throwable) {
+                continue;
+            }
             if (!is_int($level)) {
-                return false;
+                continue;
             }
 
             // Level 1 means only the ORM save() opened the transaction (the expected case).
             // Level >= 2 means the host wrapped the save in its own transactional() block.
             return $level > 1;
-        } catch (Throwable) {
-            // If reflection fails for any reason (future CakePHP version renames the property),
-            // be conservative and treat as wrapped to avoid corrupting host transactions.
-            return true;
         }
+
+        // Could not introspect transaction depth on any known property layout.
+        // Be conservative: treat as host-wrapped so we DO NOT force-commit on
+        // top of a host transaction. Bouncer records will roll back with the
+        // host if the host rolls back, which is the lesser of two evils.
+        Log::warning(
+            'Bouncer: unable to detect transaction nesting depth on the connection '
+            . '(no known transaction-level property found). Assuming the host '
+            . 'transaction wraps the save and skipping force-commit; bouncer '
+            . 'records will participate in the host transaction. If your CakePHP '
+            . 'version exposes transaction depth under a new property name, extend '
+            . 'BouncerBehavior::TRANSACTION_LEVEL_CANDIDATES accordingly.',
+            ['scope' => ['bouncer']],
+        );
+
+        return true;
     }
 
     /**

--- a/tests/Fixture/BouncerRecordsFixture.php
+++ b/tests/Fixture/BouncerRecordsFixture.php
@@ -44,6 +44,7 @@ class BouncerRecordsFixture extends TestFixture
             'idx_status' => ['type' => 'index', 'columns' => ['status']],
             'idx_created' => ['type' => 'index', 'columns' => ['created']],
             'idx_source_primary_status' => ['type' => 'index', 'columns' => ['source', 'primary_key', 'status']],
+            'bouncer_pending_lookup' => ['type' => 'index', 'columns' => ['source', 'primary_key', 'status', 'user_id']],
         ],
     ];
 

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Bouncer\Test\TestCase\Model\Behavior;
 
+use Bouncer\Model\Behavior\BouncerBehavior;
 use Bouncer\Model\Entity\BouncerRecord;
+use Cake\Database\Connection;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\TestSuite\TestCase;
 use Throwable;
@@ -1826,6 +1828,44 @@ class BouncerBehaviorTest extends TestCase
             'Seed Title',
             $hostRow->title,
             'Host transaction rollback was lost — Bouncer force-committed the outer transaction.',
+        );
+    }
+
+    /**
+     * Regression: if cake-core ever renames the protected `_transactionLevel`
+     * property (it is a 4.x-style legacy convention), the behavior must NOT
+     * silently flip into the unsafe "not wrapped → force-commit" branch.
+     * Probing all known property names should fail-safe to `true` (treat as
+     * host-wrapped and SKIP force-commit).
+     *
+     * Models the rename by subclassing the behavior and pointing its
+     * candidate-property list at names that don't exist on the real
+     * Connection class.
+     *
+     * @return void
+     */
+    public function testIsHostTransactionWrappedFailsSafeWhenPropertyMissing(): void
+    {
+        $this->Articles->addBehavior('Bouncer.Bouncer');
+        $connection = $this->Articles->getConnection();
+
+        $behavior = new class ($this->Articles) extends BouncerBehavior {
+            /**
+             * @var array
+             */
+            protected const TRANSACTION_LEVEL_CANDIDATES = ['__no_such_property__', '__also_missing__'];
+
+            public function callIsHostTransactionWrapped(Connection $connection): bool
+            {
+                return $this->isHostTransactionWrapped($connection);
+            }
+        };
+
+        $this->assertTrue(
+            $behavior->callIsHostTransactionWrapped($connection),
+            'When no candidate property is found on the connection, the safe default is to '
+            . 'treat the transaction as host-wrapped (skip force-commit). Returning false here '
+            . 'would mean force-committing on top of a host transaction — the dangerous direction.',
         );
     }
 }


### PR DESCRIPTION
## Summary

Two related correctness items from the merged review:

### 1. Transaction-depth detection is rename-safe and fails safe

`BouncerBehavior::isHostTransactionWrapped()` introspects CakePHP's protected transaction-level property via reflection because the `Connection` class doesn't expose nesting depth publicly. The previous implementation only probed the literal name `_transactionLevel`. If cake-core ever renames it (the underscore prefix is a 4.x convention the project is gradually shedding), `hasProperty('_transactionLevel')` returns false and the method falls through with `return false` — *i.e.* "not host-wrapped, go ahead and force-commit". That's the dangerous direction: force-committing on top of a host-opened transaction silently revokes the host's ability to roll back.

This change:
- Lists candidate property names in `TRANSACTION_LEVEL_CANDIDATES` (current `_transactionLevel`, plus the likely future `transactionLevel`).
- Iterates the candidates; uses the first one that exists and yields an int.
- If none match, logs a warning at info level and returns true — fail safe (skip force-commit; let the bouncer record participate in the host transaction and roll back with it if the host rolls back).
- Uses static:: so subclasses can override the candidate list (used by the new regression test that simulates a future rename).

### 2. Extend pending-draft composite index to include user_id

The merged review noted the absence of an index covering `BouncerRecordsTable::findPendingForRecord($source, $primaryKey, $userId)` — actually a composite `(source, primary_key, status)` already shipped in the original migration, but `user_id` was a residual filter on top. This adds a new migration that extends the composite to `(source, primary_key, status, user_id)` so the per-user save-time lookup is index-only.

The released migration is left untouched (per the rule on never editing released migrations). The standalone `(user_id)` index from the original migration is preserved for the admin-side "all pending drafts by user X" view.

## Tests

- `testIsHostTransactionWrappedFailsSafeWhenPropertyMissing` — subclasses the behavior with `TRANSACTION_LEVEL_CANDIDATES` pointing at nonexistent property names; asserts the method returns `true` (the safe direction).
- The existing `testHostTransactionalWrapDoesNotCommitOuterTransaction` end-to-end test continues to pass — proves the happy path still detects level=2 correctly under the current Cake version.

All 209 tests pass; phpcs and phpstan are clean.