### PR TITLE
Make bouncer_records.primary_key type configurable via Polymorphic.type

### DIFF
--- a/config/Migrations/20250116000000_CreateBouncerRecords.php
+++ b/config/Migrations/20250116000000_CreateBouncerRecords.php
@@ -14,11 +14,17 @@ class CreateBouncerRecords extends BaseMigration
      */
     public function up(): void
     {
-        // primary_key (polymorphic record reference), user_id and reviewer_id
-        // reference primary keys, so they follow the application's primary-key
-        // signedness. The flag is false (signed) when unset, so an unset flag yields
-        // signed columns matching the default-signed ids they reference. Unsigned only on MySQL.
+        $type = (string)Configure::read('Polymorphic.type', 'integer');
         $signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
+
+        $polymorphicOptions = [
+            'default' => null,
+            'null' => true,
+            'comment' => 'ID of record in source table, NULL for new records',
+        ];
+        if (in_array($type, ['integer', 'biginteger'], true)) {
+            $polymorphicOptions['signed'] = $signed;
+        }
 
         $this->table('bouncer_records')
             ->addColumn('id', 'integer', [
@@ -35,13 +41,7 @@ class CreateBouncerRecords extends BaseMigration
                 'null' => false,
                 'comment' => 'Table name (e.g., Articles)',
             ])
-            ->addColumn('primary_key', 'integer', [
-                'default' => null,
-                'limit' => 10,
-                'null' => true,
-                'signed' => $signed,
-                'comment' => 'ID of record in source table, NULL for new records',
-            ])
+            ->addColumn('primary_key', $type, $polymorphicOptions)
             ->addColumn('user_id', 'integer', [
                 'default' => null,
                 'limit' => 10,

--- a/docs/features/approval-workflow.md
+++ b/docs/features/approval-workflow.md
@@ -159,4 +159,4 @@ if ($bouncerRecord->isEditProposal() && $bouncerRecord->canDetectStaleness()) {
 
 Bundled migrations use integer columns. UUID-keyed apps need to copy and
 adjust them — see
-[Configuration → UUID Primary Keys](../guide/configuration#uuid-primary-keys).
+[Configuration → Polymorphic Column Type](../guide/configuration#polymorphic-column-type).

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -175,16 +175,20 @@ record-view routes. Plugin-aware.
 Placeholders for the array/string forms: `{source}`, `{plugin}`, `{table}`,
 `{primary_key}`.
 
-## Polymorphic Column Type (`Polymorphic.type`)
+## Polymorphic Column Type
 
 The `bouncer_records.primary_key` column is polymorphic — it stores the
 primary key of whatever source table a record belongs to. Its column type
-is controlled by the global `Polymorphic.type` config key (shared across
-the plugin family):
+is controlled by the `Polymorphic.type` config key (shared across the
+plugin family).
+
+Set this key in `config/app.php` **before** running the plugin migration:
 
 ```php
-// config/app.php or config/app_local.php
-Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
+// config/app.php (merged into Configure at bootstrap, including the migrations CLI)
+'Polymorphic' => [
+    'type' => 'uuid', // integer (default) | biginteger | uuid | binaryuuid
+],
 ```
 
 | Value | Column type | Signedness |
@@ -194,11 +198,10 @@ Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger 
 | `uuid` | `CHAR(36)` | n/a |
 | `binaryuuid` | `BINARY(16)` | n/a |
 
-Set this key **before** running the plugin migration. For UUID apps:
-
-```php
-Configure::write('Polymorphic.type', 'uuid');
-```
+This sets the column type for **fresh installs**. Existing installs already
+have a column in place; to change its type you need an app-side migration
+that alters `bouncer_records.primary_key` — the plugin migration will not
+re-run on an existing schema.
 
 Then run the migration normally — no need to copy or adapt it.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -175,32 +175,32 @@ record-view routes. Plugin-aware.
 Placeholders for the array/string forms: `{source}`, `{plugin}`, `{table}`,
 `{primary_key}`.
 
-## UUID Primary Keys
+## Polymorphic Column Type (`Polymorphic.type`)
 
-If your application uses UUID primary keys or UUID user IDs, the bundled
-migration's integer columns won't match. Copy and adapt:
-
-```bash
-cp vendor/dereuromark/cakephp-bouncer/config/Migrations/*.php config/Migrations/
-```
-
-Then change column types as needed, e.g.:
+The `bouncer_records.primary_key` column is polymorphic — it stores the
+primary key of whatever source table a record belongs to. Its column type
+is controlled by the global `Polymorphic.type` config key (shared across
+the plugin family):
 
 ```php
-->addColumn('primary_key', 'uuid', [
-    'default' => null,
-    'null'    => true,
-    'comment' => 'ID of record in source table, NULL for new records',
-])
-->addColumn('user_id', 'uuid', [
-    'default' => null,
-    'null'    => false,
-])
-->addColumn('reviewer_id', 'uuid', [
-    'default' => null,
-    'null'    => true,
-])
+// config/app.php or config/app_local.php
+Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
 ```
 
-Don't run the plugin's own migration when you've taken over with a copied
-version — your app migration is now the source of truth.
+| Value | Column type | Signedness |
+|---|---|---|
+| `integer` (default) | `INT` | follows `Migrations.unsigned_primary_keys` |
+| `biginteger` | `BIGINT` | follows `Migrations.unsigned_primary_keys` |
+| `uuid` | `CHAR(36)` | n/a |
+| `binaryuuid` | `BINARY(16)` | n/a |
+
+Set this key **before** running the plugin migration. For UUID apps:
+
+```php
+Configure::write('Polymorphic.type', 'uuid');
+```
+
+Then run the migration normally — no need to copy or adapt it.
+
+The concrete FK columns `user_id` and `reviewer_id` always remain
+`integer` and follow `Migrations.unsigned_primary_keys` independently.


### PR DESCRIPTION
## Problem

`bouncer_records.primary_key` is a polymorphic reference — it points at an arbitrary host record's primary key, so its column type should match whatever the host uses. It was hardcoded as `integer`, which cannot match apps whose host records use `biginteger` or UUID primary keys.

## Fix

The polymorphic column now follows a single global config key, `Polymorphic.type`, shared across the polymorphic-FK plugins:

```php
// config/app.php or config/app_local.php
Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
```

- Default `integer` (the CakePHP default), so behavior is unchanged for the common case.
- For the integer variants, signedness follows `Migrations.unsigned_primary_keys`; `uuid` / `binaryuuid` set no signedness.
- The concrete FK columns `user_id` and `reviewer_id` stay `integer` and are unaffected.

Editing the create migration sets the default for fresh installs; existing installs are unaffected (the create migration does not re-run). Type/signedness only take effect on MySQL for the integer variants.
