### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -90,6 +90,8 @@ class BouncerController extends AppController
 
         try {
             $allowed = $check($this->request) === true;
+        } catch (ForbiddenException $e) {
+            throw $e;
         } catch (Throwable $e) {
             Log::warning(sprintf('Bouncer.accessCheck threw %s: %s', $e::class, $e->getMessage()));
 

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -90,8 +90,6 @@ class BouncerController extends AppController
 
         try {
             $allowed = $check($this->request) === true;
-        } catch (ForbiddenException $e) {
-            throw $e;
         } catch (Throwable $e) {
             Log::warning(sprintf('Bouncer.accessCheck threw %s: %s', $e::class, $e->getMessage()));
 
@@ -141,7 +139,7 @@ class BouncerController extends AppController
             ->extract('source')
             ->toArray();
 
-        $this->set(compact('bouncerRecords', 'sources', 'status', 'source', 'userId'));
+        $this->set(['bouncerRecords' => $bouncerRecords, 'sources' => $sources, 'status' => $status, 'source' => $source, 'userId' => $userId]);
 
         return null;
     }
@@ -184,12 +182,12 @@ class BouncerController extends AppController
                         }
                     }
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->Flash->warning('The original record no longer exists.');
             }
         }
 
-        $this->set(compact('bouncerRecord', 'currentRecord', 'conflict'));
+        $this->set(['bouncerRecord' => $bouncerRecord, 'currentRecord' => $currentRecord, 'conflict' => $conflict]);
 
         return null;
     }
@@ -221,7 +219,7 @@ class BouncerController extends AppController
         try {
             $sourceTable = $this->fetchTable($bouncerRecord->source);
             $currentRecord = $sourceTable->get($bouncerRecord->primary_key);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->Flash->error('The original record no longer exists.');
 
             return $this->redirect(['action' => 'index']);
@@ -267,7 +265,7 @@ class BouncerController extends AppController
             }
         }
 
-        $this->set(compact('bouncerRecord', 'currentRecord', 'conflict'));
+        $this->set(['bouncerRecord' => $bouncerRecord, 'currentRecord' => $currentRecord, 'conflict' => $conflict]);
 
         return null;
     }
@@ -426,7 +424,7 @@ class BouncerController extends AppController
                     // Set merged data - this prevents the behavior from auto-merging again
                     $bouncerRecord->setMergedData($conflict['merged']);
                 }
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Source record no longer exists - continue with approval (will fail gracefully)
             }
         }

--- a/src/Controller/Admin/BouncerController.php
+++ b/src/Controller/Admin/BouncerController.php
@@ -139,7 +139,7 @@ class BouncerController extends AppController
             ->extract('source')
             ->toArray();
 
-        $this->set(['bouncerRecords' => $bouncerRecords, 'sources' => $sources, 'status' => $status, 'source' => $source, 'userId' => $userId]);
+        $this->set(compact('bouncerRecords', 'sources', 'status', 'source', 'userId'));
 
         return null;
     }
@@ -187,7 +187,7 @@ class BouncerController extends AppController
             }
         }
 
-        $this->set(['bouncerRecord' => $bouncerRecord, 'currentRecord' => $currentRecord, 'conflict' => $conflict]);
+        $this->set(compact('bouncerRecord', 'currentRecord', 'conflict'));
 
         return null;
     }
@@ -265,7 +265,7 @@ class BouncerController extends AppController
             }
         }
 
-        $this->set(['bouncerRecord' => $bouncerRecord, 'currentRecord' => $currentRecord, 'conflict' => $conflict]);
+        $this->set(compact('bouncerRecord', 'currentRecord', 'conflict'));
 
         return null;
     }

--- a/src/Lib/DiffLib.php
+++ b/src/Lib/DiffLib.php
@@ -139,9 +139,9 @@ class DiffLib
                 $newNum++;
                 $html .= '<tr class="unchanged">';
                 $html .= '<td class="line-num">' . $oldNum . '</td>';
-                $html .= '<td>' . htmlspecialchars((string) $row['old']) . '</td>';
+                $html .= '<td>' . htmlspecialchars((string)$row['old']) . '</td>';
                 $html .= '<td class="line-num">' . $newNum . '</td>';
-                $html .= '<td>' . htmlspecialchars((string) $row['new']) . '</td>';
+                $html .= '<td>' . htmlspecialchars((string)$row['new']) . '</td>';
                 $html .= '</tr>';
             } else {
                 $oldNum++;
@@ -154,7 +154,7 @@ class DiffLib
                 } elseif ($row['old'] === '') {
                     $html .= '<td class="old"><del class="empty-line">↵</del></td>';
                 } else {
-                    $html .= '<td class="old">' . ($row['old'] !== null ? '<del>' . htmlspecialchars((string) $row['old']) . '</del>' : '') . '</td>';
+                    $html .= '<td class="old">' . ($row['old'] !== null ? '<del>' . htmlspecialchars((string)$row['old']) . '</del>' : '') . '</td>';
                 }
 
                 $html .= '<td class="line-num new">' . ($row['new'] !== null ? $newNum : '') . '</td>';
@@ -164,7 +164,7 @@ class DiffLib
                 } elseif ($row['new'] === '') {
                     $html .= '<td class="new"><ins class="empty-line">↵</ins></td>';
                 } else {
-                    $html .= '<td class="new">' . ($row['new'] !== null ? '<ins>' . htmlspecialchars((string) $row['new']) . '</ins>' : '') . '</td>';
+                    $html .= '<td class="new">' . ($row['new'] !== null ? '<ins>' . htmlspecialchars((string)$row['new']) . '</ins>' : '') . '</td>';
                 }
 
                 $html .= '</tr>';
@@ -254,7 +254,7 @@ class DiffLib
             }
             $lastShownIndex = $item['origIndex'];
 
-            $line = rtrim((string) $item['line'], "\r\n");
+            $line = rtrim((string)$item['line'], "\r\n");
             $lineNum++;
 
             switch ($item['type']) {

--- a/src/Lib/DiffLib.php
+++ b/src/Lib/DiffLib.php
@@ -139,9 +139,9 @@ class DiffLib
                 $newNum++;
                 $html .= '<tr class="unchanged">';
                 $html .= '<td class="line-num">' . $oldNum . '</td>';
-                $html .= '<td>' . htmlspecialchars($row['old']) . '</td>';
+                $html .= '<td>' . htmlspecialchars((string) $row['old']) . '</td>';
                 $html .= '<td class="line-num">' . $newNum . '</td>';
-                $html .= '<td>' . htmlspecialchars($row['new']) . '</td>';
+                $html .= '<td>' . htmlspecialchars((string) $row['new']) . '</td>';
                 $html .= '</tr>';
             } else {
                 $oldNum++;
@@ -154,7 +154,7 @@ class DiffLib
                 } elseif ($row['old'] === '') {
                     $html .= '<td class="old"><del class="empty-line">↵</del></td>';
                 } else {
-                    $html .= '<td class="old">' . ($row['old'] !== null ? '<del>' . htmlspecialchars($row['old']) . '</del>' : '') . '</td>';
+                    $html .= '<td class="old">' . ($row['old'] !== null ? '<del>' . htmlspecialchars((string) $row['old']) . '</del>' : '') . '</td>';
                 }
 
                 $html .= '<td class="line-num new">' . ($row['new'] !== null ? $newNum : '') . '</td>';
@@ -164,7 +164,7 @@ class DiffLib
                 } elseif ($row['new'] === '') {
                     $html .= '<td class="new"><ins class="empty-line">↵</ins></td>';
                 } else {
-                    $html .= '<td class="new">' . ($row['new'] !== null ? '<ins>' . htmlspecialchars($row['new']) . '</ins>' : '') . '</td>';
+                    $html .= '<td class="new">' . ($row['new'] !== null ? '<ins>' . htmlspecialchars((string) $row['new']) . '</ins>' : '') . '</td>';
                 }
 
                 $html .= '</tr>';
@@ -178,9 +178,7 @@ class DiffLib
             }
         }
 
-        $html .= '</tbody></table>';
-
-        return $html;
+        return $html . '</tbody></table>';
     }
 
     /**
@@ -256,7 +254,7 @@ class DiffLib
             }
             $lastShownIndex = $item['origIndex'];
 
-            $line = rtrim($item['line'], "\r\n");
+            $line = rtrim((string) $item['line'], "\r\n");
             $lineNum++;
 
             switch ($item['type']) {
@@ -300,9 +298,7 @@ class DiffLib
             }
         }
 
-        $html .= '</tbody></table>';
-
-        return $html;
+        return $html . '</tbody></table>';
     }
 
     /**
@@ -507,11 +503,7 @@ class DiffLib
 
         for ($i = 1; $i <= $m; $i++) {
             for ($j = 1; $j <= $n; $j++) {
-                if ($a[$i - 1] === $b[$j - 1]) {
-                    $dp[$i][$j] = $dp[$i - 1][$j - 1] + 1;
-                } else {
-                    $dp[$i][$j] = max($dp[$i - 1][$j], $dp[$i][$j - 1]);
-                }
+                $dp[$i][$j] = $a[$i - 1] === $b[$j - 1] ? $dp[$i - 1][$j - 1] + 1 : max($dp[$i - 1][$j], $dp[$i][$j - 1]);
             }
         }
 
@@ -643,8 +635,6 @@ class DiffLib
             }
         }
 
-        $html .= '</div></div>';
-
-        return $html;
+        return $html . '</div></div>';
     }
 }

--- a/src/Lib/ThreeWayMerge.php
+++ b/src/Lib/ThreeWayMerge.php
@@ -217,9 +217,8 @@ class ThreeWayMerge
         $result .= $firstReplacement;
         $result .= mb_substr($original, $firstEnd, $secondStart - $firstEnd);
         $result .= $secondReplacement;
-        $result .= mb_substr($original, $secondEnd);
 
-        return $result;
+        return $result . mb_substr($original, $secondEnd);
     }
 
     /**
@@ -326,7 +325,7 @@ class ThreeWayMerge
             return '';
         }
 
-        $reversed = array_map(fn ($s) => $this->reverseString($s), $strings);
+        $reversed = array_map($this->reverseString(...), $strings);
         $prefix = $this->commonPrefix($reversed);
 
         return $this->reverseString($prefix);

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -399,7 +399,7 @@ class BouncerBehavior extends Behavior
 
         if ($existingDraft) {
             // Check if existing draft is a delete (different type)
-            $existingData = json_decode($existingDraft->get('data'), true) ?: [];
+            $existingData = json_decode((string) $existingDraft->get('data'), true) ?: [];
             $isExistingDelete = isset($existingData['_delete']) && $existingData['_delete'] === true;
 
             if ($isExistingDelete) {
@@ -577,7 +577,7 @@ class BouncerBehavior extends Behavior
 
         if ($existingDraft) {
             // Check if existing draft is also a delete (same type)
-            $existingData = json_decode($existingDraft->get('data'), true) ?: [];
+            $existingData = json_decode((string) $existingDraft->get('data'), true) ?: [];
             $isExistingDelete = isset($existingData['_delete']) && $existingData['_delete'] === true;
 
             if ($isExistingDelete) {
@@ -802,11 +802,7 @@ class BouncerBehavior extends Behavior
 
         // Check exempt users (fallback for backward compatibility)
         $userId = $this->getUserId($entity, $options);
-        if ($userId && in_array($userId, $this->getConfig('exemptUsers'), true)) {
-            return true;
-        }
-
-        return false;
+        return $userId && in_array($userId, $this->getConfig('exemptUsers'), true);
     }
 
     /**

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -399,7 +399,7 @@ class BouncerBehavior extends Behavior
 
         if ($existingDraft) {
             // Check if existing draft is a delete (different type)
-            $existingData = json_decode((string) $existingDraft->get('data'), true) ?: [];
+            $existingData = json_decode((string)$existingDraft->get('data'), true) ?: [];
             $isExistingDelete = isset($existingData['_delete']) && $existingData['_delete'] === true;
 
             if ($isExistingDelete) {
@@ -577,7 +577,7 @@ class BouncerBehavior extends Behavior
 
         if ($existingDraft) {
             // Check if existing draft is also a delete (same type)
-            $existingData = json_decode((string) $existingDraft->get('data'), true) ?: [];
+            $existingData = json_decode((string)$existingDraft->get('data'), true) ?: [];
             $isExistingDelete = isset($existingData['_delete']) && $existingData['_delete'] === true;
 
             if ($isExistingDelete) {
@@ -802,6 +802,7 @@ class BouncerBehavior extends Behavior
 
         // Check exempt users (fallback for backward compatibility)
         $userId = $this->getUserId($entity, $options);
+
         return $userId && in_array($userId, $this->getConfig('exemptUsers'), true);
     }
 

--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -376,6 +376,7 @@ class BouncerBehavior extends Behavior
         $source = $this->_table->getRegistryAlias();
 
         // Check if user already has a pending draft
+        /** @var \Bouncer\Model\Entity\BouncerRecord|null $existingDraft */
         $existingDraft = $bouncerTable->findPendingForRecord(
             $source,
             $primaryKey,
@@ -388,6 +389,7 @@ class BouncerBehavior extends Behavior
         $originalModified = null;
         if (!$isNew) {
             // For edits, store the current state as original
+            /** @var \Cake\Datasource\EntityInterface $original */
             $original = $this->_table->get($primaryKey);
             $originalData = $this->serializeEntity($original);
             // Capture modification timestamp for conflict detection
@@ -561,6 +563,7 @@ class BouncerBehavior extends Behavior
         $source = $this->_table->getRegistryAlias();
 
         // Check if user already has a pending draft for this record
+        /** @var \Bouncer\Model\Entity\BouncerRecord|null $existingDraft */
         $existingDraft = $bouncerTable->findPendingForRecord(
             $source,
             $primaryKey,
@@ -859,6 +862,7 @@ class BouncerBehavior extends Behavior
         /** @var \Bouncer\Model\Table\BouncerRecordsTable $bouncerTable */
         $bouncerTable = $this->fetchTable('Bouncer.BouncerRecords');
 
+        /** @var \Bouncer\Model\Entity\BouncerRecord|null $existingDraft */
         $existingDraft = $bouncerTable->findPendingForRecord(
             $this->_table->getRegistryAlias(),
             $primaryKey,
@@ -887,11 +891,14 @@ class BouncerBehavior extends Behavior
         /** @var \Bouncer\Model\Table\BouncerRecordsTable $bouncerTable */
         $bouncerTable = $this->fetchTable('Bouncer.BouncerRecords');
 
-        return $bouncerTable->findPendingForRecord(
+        /** @var \Bouncer\Model\Entity\BouncerRecord|null $draft */
+        $draft = $bouncerTable->findPendingForRecord(
             $this->_table->getRegistryAlias(),
             $primaryKey,
             $userId,
         )->first();
+
+        return $draft;
     }
 
     /**
@@ -1000,6 +1007,7 @@ class BouncerBehavior extends Behavior
             && $bouncerRecord->isEditProposal()
             && $bouncerRecord->canDetectStaleness()
         ) {
+            /** @var \Cake\Datasource\EntityInterface $currentRecord */
             $currentRecord = $this->_table->get($bouncerRecord->primary_key);
             $currentModified = $currentRecord->get('modified') ?? $currentRecord->get('created');
 
@@ -1028,6 +1036,7 @@ class BouncerBehavior extends Behavior
         // Check if this is a delete operation
         if (isset($data['_delete']) && $data['_delete']) {
             // This is a delete operation
+            /** @var \Cake\Datasource\EntityInterface $entity */
             $entity = $this->_table->get($bouncerRecord->primary_key);
             $options['bypassBouncer'] = true;
 
@@ -1039,6 +1048,7 @@ class BouncerBehavior extends Behavior
             $entity = $this->_table->newEntity($data);
         } else {
             // Load and patch existing entity
+            /** @var \Cake\Datasource\EntityInterface $entity */
             $entity = $this->_table->get($bouncerRecord->primary_key);
             $entity = $this->_table->patchEntity($entity, $data);
         }

--- a/src/Model/Entity/BouncerRecord.php
+++ b/src/Model/Entity/BouncerRecord.php
@@ -64,7 +64,7 @@ class BouncerRecord extends Entity
             return [];
         }
 
-        return json_decode((string) $this->data, true) ?: [];
+        return json_decode((string)$this->data, true) ?: [];
     }
 
     /**
@@ -78,7 +78,7 @@ class BouncerRecord extends Entity
             return [];
         }
 
-        return json_decode((string) $this->original_data, true) ?: [];
+        return json_decode((string)$this->original_data, true) ?: [];
     }
 
     /**

--- a/src/Model/Entity/BouncerRecord.php
+++ b/src/Model/Entity/BouncerRecord.php
@@ -64,7 +64,7 @@ class BouncerRecord extends Entity
             return [];
         }
 
-        return json_decode($this->data, true) ?: [];
+        return json_decode((string) $this->data, true) ?: [];
     }
 
     /**
@@ -78,7 +78,7 @@ class BouncerRecord extends Entity
             return [];
         }
 
-        return json_decode($this->original_data, true) ?: [];
+        return json_decode((string) $this->original_data, true) ?: [];
     }
 
     /**

--- a/src/View/Helper/BouncerHelper.php
+++ b/src/View/Helper/BouncerHelper.php
@@ -186,7 +186,7 @@ class BouncerHelper extends Helper
 
         $diffs = [];
         foreach ($allFields as $field) {
-            if (in_array($field, ['created', 'modified', 'id'], true) || str_starts_with((string) $field, '_')) {
+            if (in_array($field, ['created', 'modified', 'id'], true) || str_starts_with((string)$field, '_')) {
                 continue;
             }
             if (!array_key_exists($field, $proposedData)) {

--- a/src/View/Helper/BouncerHelper.php
+++ b/src/View/Helper/BouncerHelper.php
@@ -186,7 +186,7 @@ class BouncerHelper extends Helper
 
         $diffs = [];
         foreach ($allFields as $field) {
-            if (in_array($field, ['created', 'modified', 'id'], true) || str_starts_with($field, '_')) {
+            if (in_array($field, ['created', 'modified', 'id'], true) || str_starts_with((string) $field, '_')) {
                 continue;
             }
             if (!array_key_exists($field, $proposedData)) {
@@ -299,9 +299,8 @@ class BouncerHelper extends Helper
         $output .= '<span class="text-muted">' . __d('bouncer', 'After:') . '</span>';
         $output .= '<div class="p-2 bg-warning border rounded"><ins><strong>' . h($proposedStr) . '</strong></ins></div>';
         $output .= '</div>';
-        $output .= '</div>';
 
-        return $output;
+        return $output . '</div>';
     }
 
     /**
@@ -330,9 +329,7 @@ class BouncerHelper extends Helper
             $output .= '</tr>';
         }
 
-        $output .= '</tbody></table>';
-
-        return $output;
+        return $output . '</tbody></table>';
     }
 
     /**
@@ -348,9 +345,8 @@ class BouncerHelper extends Helper
         $output .= '<summary><strong>' . __d('bouncer', 'Raw JSON Data') . '</strong></summary>';
         $output .= '<pre class="bg-light p-3 mt-2"><code>';
         $output .= h(json_encode($bouncerRecord->getData(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
-        $output .= '</code></pre></details>';
 
-        return $output;
+        return $output . '</code></pre></details>';
     }
 
     /**

--- a/tests/TestCase/Lib/DiffLibTest.php
+++ b/tests/TestCase/Lib/DiffLibTest.php
@@ -13,7 +13,6 @@ class DiffLibTest extends TestCase
 
     public function setUp(): void
     {
-        parent::setUp();
         $this->diffLib = new DiffLib();
     }
 

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
@@ -399,13 +399,13 @@ class BouncerBehaviorTest extends TestCase
         $bouncerRecord = $this->Articles->getBehavior('Bouncer')->getLastBouncerRecord();
         $this->assertNotNull($bouncerRecord);
 
-        $originalData = json_decode($bouncerRecord->original_data, true);
+        $originalData = json_decode((string) $bouncerRecord->original_data, true);
         $this->assertNotEmpty($originalData, 'original_data should not be empty for edits');
         $this->assertEquals('Original Title', $originalData['title']);
         $this->assertEquals('Original Body', $originalData['body']);
 
         // Check that proposed data has the updates
-        $proposedData = json_decode($bouncerRecord->data, true);
+        $proposedData = json_decode((string) $bouncerRecord->data, true);
         $this->assertEquals('Updated Title', $proposedData['title']);
         $this->assertEquals('Updated Body', $proposedData['body']);
     }
@@ -442,7 +442,7 @@ class BouncerBehaviorTest extends TestCase
         $this->Articles->save($article, ['bouncerUserId' => 1]);
 
         $bouncerRecord = $this->Articles->getBehavior('Bouncer')->getLastBouncerRecord();
-        $originalData = json_decode($bouncerRecord->original_data, true);
+        $originalData = json_decode((string) $bouncerRecord->original_data, true);
 
         // original_data should contain ALL fields from the original article
         // not just the dirty ones
@@ -493,7 +493,7 @@ class BouncerBehaviorTest extends TestCase
         $this->assertTrue($data['_delete']);
 
         // Original data should be stored
-        $originalData = json_decode($bouncerRecord->original_data, true);
+        $originalData = json_decode((string) $bouncerRecord->original_data, true);
         $this->assertEquals('Test Article', $originalData['title']);
         $this->assertEquals('Test body', $originalData['body']);
 
@@ -1351,7 +1351,7 @@ class BouncerBehaviorTest extends TestCase
 
         $bouncerRecord = $this->BouncerRecords->find()->first();
         $this->assertNotNull($bouncerRecord);
-        $this->assertEquals(255, mb_strlen($bouncerRecord->note));
+        $this->assertEquals(255, mb_strlen((string) $bouncerRecord->note));
         $this->assertEquals(str_repeat('a', 255), $bouncerRecord->note);
     }
 

--- a/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/BouncerBehaviorTest.php
@@ -399,13 +399,13 @@ class BouncerBehaviorTest extends TestCase
         $bouncerRecord = $this->Articles->getBehavior('Bouncer')->getLastBouncerRecord();
         $this->assertNotNull($bouncerRecord);
 
-        $originalData = json_decode((string) $bouncerRecord->original_data, true);
+        $originalData = json_decode((string)$bouncerRecord->original_data, true);
         $this->assertNotEmpty($originalData, 'original_data should not be empty for edits');
         $this->assertEquals('Original Title', $originalData['title']);
         $this->assertEquals('Original Body', $originalData['body']);
 
         // Check that proposed data has the updates
-        $proposedData = json_decode((string) $bouncerRecord->data, true);
+        $proposedData = json_decode((string)$bouncerRecord->data, true);
         $this->assertEquals('Updated Title', $proposedData['title']);
         $this->assertEquals('Updated Body', $proposedData['body']);
     }
@@ -442,7 +442,7 @@ class BouncerBehaviorTest extends TestCase
         $this->Articles->save($article, ['bouncerUserId' => 1]);
 
         $bouncerRecord = $this->Articles->getBehavior('Bouncer')->getLastBouncerRecord();
-        $originalData = json_decode((string) $bouncerRecord->original_data, true);
+        $originalData = json_decode((string)$bouncerRecord->original_data, true);
 
         // original_data should contain ALL fields from the original article
         // not just the dirty ones
@@ -493,7 +493,7 @@ class BouncerBehaviorTest extends TestCase
         $this->assertTrue($data['_delete']);
 
         // Original data should be stored
-        $originalData = json_decode((string) $bouncerRecord->original_data, true);
+        $originalData = json_decode((string)$bouncerRecord->original_data, true);
         $this->assertEquals('Test Article', $originalData['title']);
         $this->assertEquals('Test body', $originalData['body']);
 
@@ -1351,7 +1351,7 @@ class BouncerBehaviorTest extends TestCase
 
         $bouncerRecord = $this->BouncerRecords->find()->first();
         $this->assertNotNull($bouncerRecord);
-        $this->assertEquals(255, mb_strlen((string) $bouncerRecord->note));
+        $this->assertEquals(255, mb_strlen((string)$bouncerRecord->note));
         $this->assertEquals(str_repeat('a', 255), $bouncerRecord->note);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaLoader;
 use TestApp\Controller\AppController;
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once 'vendor/autoload.php';
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaLoader;
 use TestApp\Controller\AppController;
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -19,7 +19,7 @@ foreach ($iterator as $file) {
     $class = 'Bouncer\\Test\\Fixture\\' . $name . 'Fixture';
     try {
         $object = (new ReflectionClass($class))->getProperty('fields');
-    } catch (ReflectionException $e) {
+    } catch (ReflectionException) {
         continue;
     }
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.