### PR TITLE
Fix PHPCS issues after sniffer update

### DIFF
--- a/src/Model/Behavior/BouncerBehavior.php
+++ b/src/Model/Behavior/BouncerBehavior.php
@@ -703,7 +703,7 @@ class BouncerBehavior extends Behavior
      *
      * @return string|int|null
      */
-    protected function getUserId(EntityInterface $entity, ArrayObject $options): int|string|null
+    protected function getUserId(EntityInterface $entity, ArrayObject $options): string|int|null
     {
         $userField = $this->getConfig('userField');
 
@@ -850,7 +850,7 @@ class BouncerBehavior extends Behavior
      *
      * @return void
      */
-    protected function removeRevertedDraft(EntityInterface $entity, int|string $userId): void
+    protected function removeRevertedDraft(EntityInterface $entity, string|int $userId): void
     {
         $primaryKeyField = $this->_table->getPrimaryKey();
         $primaryKey = $entity->get(is_array($primaryKeyField) ? $primaryKeyField[0] : $primaryKeyField);
@@ -886,7 +886,7 @@ class BouncerBehavior extends Behavior
      *
      * @return \Bouncer\Model\Entity\BouncerRecord|null
      */
-    public function loadDraft(int|string $primaryKey, int|string $userId): ?BouncerRecord
+    public function loadDraft(string|int $primaryKey, string|int $userId): ?BouncerRecord
     {
         /** @var \Bouncer\Model\Table\BouncerRecordsTable $bouncerTable */
         $bouncerTable = $this->fetchTable('Bouncer.BouncerRecords');
@@ -911,7 +911,7 @@ class BouncerBehavior extends Behavior
      *
      * @return bool
      */
-    public function hasPendingDraft(int|string|null $primaryKey, int|string $userId): bool
+    public function hasPendingDraft(string|int|null $primaryKey, string|int $userId): bool
     {
         if ($primaryKey === null) {
             return false;
@@ -943,7 +943,7 @@ class BouncerBehavior extends Behavior
      *
      * @return \Bouncer\Model\Entity\BouncerRecord|null The draft entity if found and applied, null otherwise
      */
-    public function withDraft(EntityInterface $entity, int|string $userId): ?BouncerRecord
+    public function withDraft(EntityInterface $entity, string|int $userId): ?BouncerRecord
     {
         $primaryKeyField = $this->_table->getPrimaryKey();
         $primaryKey = $entity->get(is_array($primaryKeyField) ? $primaryKeyField[0] : $primaryKeyField);

--- a/src/Model/Table/BouncerRecordsTable.php
+++ b/src/Model/Table/BouncerRecordsTable.php
@@ -132,7 +132,7 @@ class BouncerRecordsTable extends Table
      *
      * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findPendingForRecord(string $source, int|string|null $primaryKey, int|string|null $userId = null)
+    public function findPendingForRecord(string $source, string|int|null $primaryKey, string|int|null $userId = null)
     {
         $query = $this->find()
             ->where([
@@ -178,7 +178,7 @@ class BouncerRecordsTable extends Table
      *
      * @return int Number of records superseded
      */
-    public function supersedeOthers(string $source, int|string|null $primaryKey, int $excludeId): int
+    public function supersedeOthers(string $source, string|int|null $primaryKey, int $excludeId): int
     {
         return $this->updateAll(
             ['status' => 'superseded'],

--- a/src/View/Helper/BouncerHelper.php
+++ b/src/View/Helper/BouncerHelper.php
@@ -622,9 +622,9 @@ JS;
      * @return array|string|null URL or null if no link
      */
     protected function buildUrl(
-        callable|string|array $linkConfig,
+        callable|array|string $linkConfig,
         array $replacements,
-    ): string|array|null {
+    ): array|string|null {
         if (is_callable($linkConfig)) {
             return $linkConfig(...array_values($replacements));
         }
@@ -655,12 +655,12 @@ JS;
      * @return array|string|null URL or null if no link
      */
     protected function buildRecordUrl(
-        callable|string|array $linkConfig,
+        callable|array|string $linkConfig,
         string $source,
         ?string $plugin,
         string $tableName,
         string $primaryKey,
-    ): string|array|null {
+    ): array|string|null {
         if (is_callable($linkConfig)) {
             return $linkConfig($source, $primaryKey, $plugin, $tableName);
         }


### PR DESCRIPTION
## Summary
- apply PHPCBF fixes for current php-collective/code-sniffer rules
- keep `composer cs-check` green after dependency updates

## Testing
- `composer update --no-interaction --no-progress`
- `composer cs-fix`
- `composer cs-check`