### PR TITLE
Add support for sebastian/diff 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=8.2",
         "cakephp/orm": "^5.0.0",
         "ext-json": "*",
-        "sebastian/diff": "^6.0 || ^7.0 || ^8.0"
+        "sebastian/diff": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "cakephp/cakephp": "^5.1.0",

--- a/src/Lib/DiffLib.php
+++ b/src/Lib/DiffLib.php
@@ -3,7 +3,7 @@
 namespace Bouncer\Lib;
 
 use SebastianBergmann\Diff\Differ;
-use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
 /**
  * A library for generating HTML diffs between two strings.
@@ -536,7 +536,7 @@ class DiffLib
      */
     protected function getDiffArray(string $old, string $new): array
     {
-        $builder = new UnifiedDiffOutputBuilder();
+        $builder = new DiffOnlyOutputBuilder();
         $differ = new Differ($builder);
 
         return $differ->diffToArray($old, $new);


### PR DESCRIPTION
Adds `sebastian/diff ^9.0` to the supported version range.

`sebastian/diff` 9.0 removed `UnifiedDiffOutputBuilder`, so `DiffLib` now uses `DiffOnlyOutputBuilder` instead. Output is unchanged: only `diffToArray()` is consumed, and the builder choice does not affect that result. `DiffOnlyOutputBuilder` exists across the 6/7/8/9 generations, so the swap is safe on every supported version.

Note that diff 9 requires PHP 8.4+ and resolves only on the phpunit 13 generation. This repo's CI matrix therefore exercises diff 7.x; the `^9.0` branch is forward-compatible and was validated against the 9.0.0 API.
