### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/BouncerHelper.php
+++ b/src/View/Helper/BouncerHelper.php
@@ -26,7 +26,7 @@ class BouncerHelper extends Helper
     /**
      * Helpers to load
      *
-     * @var array
+     * @var array<int|string, array<string, mixed>|string>
      */
     protected array $helpers = ['Html'];
 


### PR DESCRIPTION
Updates helper/component annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test